### PR TITLE
Add an unshuffling feature to turn shuffled data back into csv columnar format -- which unblocks forecasting on continuous time-series data

### DIFF
--- a/data/csv_data/README.md
+++ b/data/csv_data/README.md
@@ -20,6 +20,14 @@ For example, one can utilize a beam search for each of the labels to determine
 which of the letter value pairs gives the strongest certainty of data points in
 this frame, and build the next frame up incrementally using this technique.
 
+# TOC
+
+* [Getting Started](#getting-started)
+  * [Prerequisites](#prerequisites)
+* [Usage](#usage)
+  * [Arguments](#arguments)
+  * [Example](#example)
+
 ## Getting Started
 
 ### Prerequisites
@@ -58,7 +66,15 @@ cd ../../explorations
 bash run_csv_data_training.sh
 ```
 
-6. [Optional] Create an exploration script to test training and inference with
+
+6. After running training, use the `unprocess.py` script to prepare the data for
+   graphing.
+
+```bash
+python3 unprocess.py -i <processed_data_file> -o forecast.csv --convert_to_csv
+```
+
+7. [Optional] Create an exploration script to test training and inference with
    and without with and without shuffling.
 
 ### Arguments

--- a/data/csv_data/clean.sh
+++ b/data/csv_data/clean.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm *.bin *.pkl *.csv 2> /dev/null

--- a/data/csv_data/process_csv.py
+++ b/data/csv_data/process_csv.py
@@ -15,9 +15,10 @@ def process_csv(input_file: str, output_file: str, shuffle: bool, exclude: list)
         csv_reader = csv.reader(csv_file)
 
         for row in csv_reader:
-            # Use the letter mapping to assign letters to values
+            # Use the letter mapping to assign letters to values, skipping empty values
             letter_value_pairs = [
-                f"{letter_mapping[i]}{val}" for i, val in enumerate(row) if i in letter_mapping
+                f"{letter_mapping[i]}{val}" for i, val in enumerate(row)
+                if i in letter_mapping and val.strip()  # Added check for non-empty values
             ]
 
             if shuffle:

--- a/data/csv_data/unprocess.py
+++ b/data/csv_data/unprocess.py
@@ -4,9 +4,11 @@ import re
 def unshuffle_data(data, labels, convert_to_csv=False):
     """
     Unshuffles data based on the specified labels and prepends the part left of the first label to each line.
+    Adds empty values for missing labels to maintain column structure.
 
     :param data: List of strings containing shuffled data.
     :param labels: List of labels to order the data by.
+    :param convert_to_csv: Boolean flag to convert output to CSV format.
     :return: List of strings with data unshuffled and prepended with the part left of the first label.
     """
     unshuffled_data = []
@@ -15,23 +17,20 @@ def unshuffle_data(data, labels, convert_to_csv=False):
         # Extracting the part before the first label
         prefix = re.match(r"[^" + "".join(labels) + "]*", line).group()
 
-        # Extracting and sorting the parts with labels
-        parts = re.findall(r"([" + "".join(labels) + "])(-?\d+\.\d+e[+-]\d+)", line)
+        # Extracting the parts with labels
+        parts_dict = {label: "" for label in labels}  # Initialize all labels with empty values
+        for label, value in re.findall(r"([" + "".join(labels) + "])(-?\d+\.\d+e[+-]\d+)", line):
+            parts_dict[label] = value
 
-        sorted_parts = sorted(
-            parts, key=lambda x: labels.index(x[0]) if x[0] in labels else len(labels)
-        )
-
+        # Forming the unshuffled line
         if convert_to_csv:
-          # Prepending the prefix and forming the unshuffled line
-          unshuffled_line = prefix + "".join(
-              f",{value}" for label, value in sorted_parts
-          )
+            unshuffled_line = prefix + "".join(
+                f",{parts_dict[label]}" for label in labels
+            )
         else:
-          # Prepending the prefix and forming the unshuffled line
-          unshuffled_line = prefix + "".join(
-              f"{label}{value}" for label, value in sorted_parts
-          )
+            unshuffled_line = prefix + "".join(
+                f"{label}{parts_dict[label]}" for label in labels
+            )
 
         unshuffled_data.append(unshuffled_line)
 

--- a/data/csv_data/unprocess.py
+++ b/data/csv_data/unprocess.py
@@ -1,0 +1,67 @@
+import argparse
+import re
+
+def unshuffle_data(data, labels, convert_to_csv=False):
+    """
+    Unshuffles data based on the specified labels and prepends the part left of the first label to each line.
+
+    :param data: List of strings containing shuffled data.
+    :param labels: List of labels to order the data by.
+    :return: List of strings with data unshuffled and prepended with the part left of the first label.
+    """
+    unshuffled_data = []
+
+    for line in data:
+        # Extracting the part before the first label
+        prefix = re.match(r"[^" + "".join(labels) + "]*", line).group()
+
+        # Extracting and sorting the parts with labels
+        parts = re.findall(r"([" + "".join(labels) + "])(-?\d+\.\d+e[+-]\d+)", line)
+
+        sorted_parts = sorted(
+            parts, key=lambda x: labels.index(x[0]) if x[0] in labels else len(labels)
+        )
+
+        if convert_to_csv:
+          # Prepending the prefix and forming the unshuffled line
+          unshuffled_line = prefix + "".join(
+              f",{value}" for label, value in sorted_parts
+          )
+        else:
+          # Prepending the prefix and forming the unshuffled line
+          unshuffled_line = prefix + "".join(
+              f"{label}{value}" for label, value in sorted_parts
+          )
+
+        unshuffled_data.append(unshuffled_line)
+
+    return unshuffled_data
+
+
+def main():
+    parser = argparse.ArgumentParser( description="Unshuffle data based on specified labels and prepend the part left of the first label.")
+    parser.add_argument("-i", "--input_file", help="Input file containing the data to be unshuffled.")
+    parser.add_argument("-o", "--output_file", nargs="?", help="Output file to write the unshuffled data. If not provided, prints to stdout.",)
+    parser.add_argument("-l", "--labels", help='Labels used to order the data (e.g., "abc")')
+    parser.add_argument("-c", "--convert_to_csv", action="store_true", help='converts file into csv')
+    args = parser.parse_args()
+
+    # Reading data from the input file
+    with open(args.input_file, "r") as file:
+        data = file.readlines()
+
+    unshuffled_data = unshuffle_data(data, list(args.labels), convert_to_csv=args.convert_to_csv)
+
+    if args.output_file:
+        # Writing to the output file
+        with open(args.output_file, "w") as file:
+            for line in unshuffled_data:
+                file.write(line + "\n")
+    else:
+        # Printing to stdout
+        for line in unshuffled_data:
+            print(line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
To plot forecast, we have to reformat the data from labelled data back into a format like csv.
Once back into CSV format, we can easily plot the forecasts given the initial timestamped csv data.

Next steps are to increase the flexibility of the scripts to permit absence of data (if so should be skipped in the labelling process, and the unshuffling should insert an empty field)