### PR TITLE
Add option for Post Layernorm Ordering

### DIFF
--- a/explorations/test_all_softmax_variations.sh
+++ b/explorations/test_all_softmax_variations.sh
@@ -1,0 +1,51 @@
+#/bin/bash
+
+# head to repo root
+cd ../
+
+dataset="shakespeare_char"
+python3 "data/${dataset}/prepare.py"
+
+softmax_variation=("constantmax" "polymax" "softermax" "sigsoftmax")
+
+max_iters="3000"
+block_size="256"
+notes="check_all_softmax_variations"
+
+# Loop over the array
+for softmax_variant in "${softmax_variation[@]}"
+do
+  python3 train.py \
+    --max_iters "$max_iters" \
+    --eval_iters 200 \
+    --eval_interval 200 \
+    --log_interval 10 \
+    --device cuda \
+    --dataset "$dataset" \
+    --use_softmax_variant \
+    --softmax_variant "${softmax_variant}" \
+    --use_softermax_xmax \
+    --tensorboard_project "${dataset}_${softmax_variant}_${max_iters}" \
+    --tensorboard_run_name "${softmax_variant}_${notes}" \
+    --block_size "$block_size" \
+    --out_dir "${dataset}_${softmax_variant}_${max_iters}_${notes}" \
+    --compile
+done
+
+# do one iteration with regular softmax
+softmax_variant="regular_softmax"
+python3 train.py \
+  --max_iters "$max_iters" \
+  --eval_iters 200 \
+  --eval_interval 200 \
+  --log_interval 10 \
+  --device cuda \
+  --dataset "$dataset" \
+  --no-use_softmax_variant \
+  --use_softermax_xmax \
+  --tensorboard_project "${dataset}_${softmax_variant}_${max_iters}" \
+  --tensorboard_run_name "${softmax_variant}_${notes}" \
+  --block_size "$block_size" \
+  --out_dir "${dataset}_${softmax_variant}_${max_iters}_${notes}" \
+  --compile
+

--- a/explorations/test_postln_preln.sh
+++ b/explorations/test_postln_preln.sh
@@ -1,0 +1,35 @@
+#/bin/bash
+
+# head to repo root
+cd ../
+
+dataset="shakespeare_char"
+python3 "data/${dataset}/prepare.py"
+
+ordering_options=("--use_post_ln" "--no-use_post_ln")
+
+max_iters="3000"
+block_size="256"
+notes="test_post_ln_and_pre_ln"
+
+# Loop over the array
+for ordering_option in "${ordering_options[@]}"
+do
+  softmax_variant="regular_softmax"
+  python3 train.py \
+    --max_iters "$max_iters" \
+    --eval_iters 200 \
+    --eval_interval 200 \
+    --log_interval 10 \
+    --device cuda \
+    --dataset "$dataset" \
+    --no-use_softmax_variant \
+    "${ordering_option}" \
+    --use_softermax_xmax \
+    --tensorboard_project "${dataset}_${softmax_variant}_${max_iters}" \
+    --tensorboard_run_name "${softmax_variant}_${notes}_${ordering_option}" \
+    --block_size "$block_size" \
+    --out_dir "${dataset}_${softmax_variant}_${max_iters}_${notes}_${ordering_option}" \
+    --compile
+done
+

--- a/model.py
+++ b/model.py
@@ -52,21 +52,23 @@ class Softermax(nn.Module):
         e_x = torch.pow(2.0, x)
         return e_x / e_x.sum(dim=self.dim, keepdim=True)
 
-# Softmax base 2, with constant denominator, and option to remove max subtraction
+# Softmax with learnable parameters for xmax and denominator
 class Constantmax(nn.Module):
-    """ Base-2 Softmax with option to remove max subtraction"""
-    def __init__(self, dim=-1, subtract_max=True, constant=1000):
+    """ Softmax with learnable parameters for xmax and denominator """
+    def __init__(self, dim=-1, initial_gamma=500):
         super().__init__()
         self.dim = dim
-        self.subtract_max = subtract_max
-        self.constant = constant
+
+        # learnable 'xmax' - beta
+        self.beta = nn.Parameter(torch.Tensor([0.0]))
+
+        # denominator - gamma
+        self.gamma = nn.Parameter(torch.Tensor([initial_gamma]))
 
     def forward(self, x):
-        if self.subtract_max:
-            max_x = x.max(dim=self.dim, keepdim=True).values
-            x = x - max_x
-        e_x = torch.pow(2.0, x)
-        return e_x / self.constant
+        x = x - self.beta
+        e_x = torch.exp(x)
+        return e_x / self.gamma
 
 # Like softermax, but parameterized to permit exploration of bases greater than 2
 class Strongermax(nn.Module):
@@ -275,7 +277,7 @@ class CausalSelfAttention(nn.Module):
             if self.softmax_variant == "constantmax":
               self.use_softermax_xmax = config.use_softermax_xmax
               self.constantmax_constant = config.constantmax_constant
-              self.softmax_layer = Constantmax(subtract_max=self.use_softermax_xmax, constant=self.constantmax_constant)
+              self.softmax_layer = Constantmax()
 
             if self.softmax_variant == "strongermax":
               self.use_softermax_xmax = config.use_softermax_xmax
@@ -440,7 +442,7 @@ class GPT(nn.Module):
             if self.softmax_variant == "constantmax":
               self.use_softermax_xmax = config.use_softermax_xmax
               self.constantmax_constant = config.constantmax_constant
-              self.softmax_layer = Constantmax(subtract_max=self.use_softermax_xmax, constant=self.constantmax_constant)
+              self.softmax_layer = Constantmax()
 
             if self.softmax_variant == "strongermax":
               self.use_softermax_xmax = config.use_softermax_xmax

--- a/train.py
+++ b/train.py
@@ -50,6 +50,7 @@ def parse_args():
     model_group.add_argument('--n_embd', default=384, type=int)
     model_group.add_argument('--dropout', default=0.2, type=float)
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument('--use_post_ln', default=False, action=argparse.BooleanOptionalAction)
 
     # Norm variations
     model_group.add_argument('--use_rmsnorm', default=True, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -62,7 +62,7 @@ def parse_args():
 
     # Softmax variations
     model_group.add_argument('--use_softmax_variant', default=False, action=argparse.BooleanOptionalAction)
-    model_group.add_argument("--softmax_variant", type=str, default="softermax", choices=["polymax", "strongermax", "softermax", "sigsoftmax", "sigsoftmax_base2"])
+    model_group.add_argument("--softmax_variant", type=str, default="softermax", choices=["constantmax", "polymax", "strongermax", "softermax", "sigsoftmax", "sigsoftmax_base2"])
 
     # Custom Softmax Variation Options
     model_group.add_argument('--use_softermax_xmax', default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
There has been research showing that post_ln (post layernorm) training
is an interesting variation, potentially leading to better results when
the model converges than pre_ln (pre-layernorm):

https://arxiv.org/abs/2004.08249

This adds an parameter to select between pre-layernorm or post-layernorm variations.

Empirically, we've found that we do actually have lower validation loss indeed when using the post-layernorm variation.