### PR TITLE
Merging advancedengineering constantmax quantization

### DIFF
--- a/explorations/constmax_training_quan.sh
+++ b/explorations/constmax_training_quan.sh
@@ -1,0 +1,48 @@
+#/bin/bash
+
+# head to repo root
+cd ../
+
+# create train.bin and val.bin splits (retaining contiguous sections of data)
+python3 data/shakespeare_char/prepare.py
+
+# start training
+# start training
+python3 train.py \
+  --max_iters 8000 \
+  --eval_iters 200 \
+  --eval_interval 200 \
+  --log_interval 10 \
+  --use_softmax_variant \
+  --softmax_variant "constantmax_quan" \
+  --tensorboard_project "softmax_explorations" \
+  --tensorboard_run_name "consmax_quan" \
+  --block_size 256  \
+  --out_dir "consmax_quan_evaluations" \
+  --compile
+
+python3 train.py \
+  --max_iters 8000 \
+  --eval_iters 200 \
+  --eval_interval 200 \
+  --log_interval 10 \
+  --use_softmax_variant \
+  --softmax_variant "constantmax" \
+  --tensorboard_project "softmax_explorations" \
+  --tensorboard_run_name "consmax_base_e" \
+  --block_size 256  \
+  --out_dir "consmax_evaluations" \
+  --compile
+
+# start training
+python3 train.py \
+  --max_iters 8000 \
+  --eval_iters 200 \
+  --eval_interval 200 \
+  --log_interval 10 \
+  --no-use_softmax_variant \
+  --tensorboard_project "softmax_explorations" \
+  --tensorboard_run_name "regular_softmax" \
+  --block_size 256  \
+  --out_dir "softmax_evaluations" \
+  --compile

--- a/explorations/test_all_softmax_variations.sh
+++ b/explorations/test_all_softmax_variations.sh
@@ -1,0 +1,51 @@
+#/bin/bash
+
+# head to repo root
+cd ../
+
+dataset="shakespeare_char"
+python3 "data/${dataset}/prepare.py"
+
+softmax_variation=("constantmax" "polymax" "softermax" "sigsoftmax")
+
+max_iters="3000"
+block_size="256"
+notes="check_all_softmax_variations"
+
+# Loop over the array
+for softmax_variant in "${softmax_variation[@]}"
+do
+  python3 train.py \
+    --max_iters "$max_iters" \
+    --eval_iters 200 \
+    --eval_interval 200 \
+    --log_interval 10 \
+    --device cuda \
+    --dataset "$dataset" \
+    --use_softmax_variant \
+    --softmax_variant "${softmax_variant}" \
+    --use_softermax_xmax \
+    --tensorboard_project "${dataset}_${softmax_variant}_${max_iters}" \
+    --tensorboard_run_name "${softmax_variant}_${notes}" \
+    --block_size "$block_size" \
+    --out_dir "${dataset}_${softmax_variant}_${max_iters}_${notes}" \
+    --compile
+done
+
+# do one iteration with regular softmax
+softmax_variant="regular_softmax"
+python3 train.py \
+  --max_iters "$max_iters" \
+  --eval_iters 200 \
+  --eval_interval 200 \
+  --log_interval 10 \
+  --device cuda \
+  --dataset "$dataset" \
+  --no-use_softmax_variant \
+  --use_softermax_xmax \
+  --tensorboard_project "${dataset}_${softmax_variant}_${max_iters}" \
+  --tensorboard_run_name "${softmax_variant}_${notes}" \
+  --block_size "$block_size" \
+  --out_dir "${dataset}_${softmax_variant}_${max_iters}_${notes}" \
+  --compile
+

--- a/explorations/test_postln_preln.sh
+++ b/explorations/test_postln_preln.sh
@@ -1,0 +1,35 @@
+#/bin/bash
+
+# head to repo root
+cd ../
+
+dataset="shakespeare_char"
+python3 "data/${dataset}/prepare.py"
+
+ordering_options=("--use_post_ln" "--no-use_post_ln")
+
+max_iters="3000"
+block_size="256"
+notes="test_post_ln_and_pre_ln"
+
+# Loop over the array
+for ordering_option in "${ordering_options[@]}"
+do
+  softmax_variant="regular_softmax"
+  python3 train.py \
+    --max_iters "$max_iters" \
+    --eval_iters 200 \
+    --eval_interval 200 \
+    --log_interval 10 \
+    --device cuda \
+    --dataset "$dataset" \
+    --no-use_softmax_variant \
+    "${ordering_option}" \
+    --use_softermax_xmax \
+    --tensorboard_project "${dataset}_${softmax_variant}_${max_iters}" \
+    --tensorboard_run_name "${softmax_variant}_${notes}_${ordering_option}" \
+    --block_size "$block_size" \
+    --out_dir "${dataset}_${softmax_variant}_${max_iters}_${notes}_${ordering_option}" \
+    --compile
+done
+

--- a/model.py
+++ b/model.py
@@ -67,8 +67,8 @@ class const_quan(torch.autograd.Function):
     @staticmethod
     def forward(ctx, beta=None, gamma=None):
         #scaling factor for beta and gamma while doing quantization
-        scale_beta=9#scaling factor for quantization, should make it as parameter
-        scale_gamma=8
+        scale_beta=100#scaling factor for quantization, should make it as parameter
+        scale_gamma=10
         beta = quantize(beta, scale_beta)
         gamma = quantize(gamma, scale_gamma)
         return dequantize(beta, scale_beta),dequantize(gamma,scale_gamma)
@@ -97,13 +97,15 @@ class Constantmax_quan(nn.Module):
 
     def forward(self, x):
         if self.training:
+            #print('fake_beta:', self.fake_beta)
+            #print('fake_gamma:', self.fake_gamma)
             self.fake_beta,self.fake_gamma=_const_quan(self.beta,self.gamma)
             x = x - self.fake_beta
             e_x = torch.exp(x)
             return e_x / self.fake_gamma
         else:
-            scale_beta=9 #scaling factor for quantization, should make it as parameter
-            scale_gamma=8
+            scale_beta=100 #scaling factor for quantization, should make it as parameter
+            scale_gamma=10
             x = x - dequantize(quantize(self.beta,scale_beta),scale_beta)
             e_x = torch.exp(x)
             return e_x/dequantize(quantize(self.gamma,scale_gamma),scale_gamma)

--- a/model.py
+++ b/model.py
@@ -52,6 +52,61 @@ class Softermax(nn.Module):
         e_x = torch.pow(2.0, x)
         return e_x / e_x.sum(dim=self.dim, keepdim=True)
 
+# Softmax base 2, with constant denominator, and option to remove max subtraction
+def quantize(tensor,scale):
+    tensor = tensor.mul(scale)
+    tensor = torch.round(tensor)
+    return tensor
+def dequantize(tensor,scale):
+    tensor = tensor.div(scale)
+    return tensor
+    
+class const_quan(torch.autograd.Function):
+    """Simulates error caused by quantization. Uses Straight-Through Estimator for Back prop"""
+    @staticmethod
+    def forward(ctx, beta=None, gamma=None):
+        #scaling factor for beta and gamma while doing quantization
+        scale_beta=100
+        scale_gamma=10
+        beta = quantize(beta, scale_beta)
+        gamma = quantize(gamma, scale_gamma)
+        return dequantize(beta, scale_beta),dequantize(gamma,scale_gamma)
+
+    @staticmethod
+    def backward(ctx, grad_gamma, grad_beta):
+        return grad_gamma, grad_beta
+
+_const_quan=const_quan.apply
+    
+class Constantmax_quan(nn.Module):
+    """ Base-e Softmax with option to remove max subtraction"""
+    def __init__(self, dim=-1, initial_gamma=500):
+        super().__init__()
+        self.dim = dim
+        
+        # demonimator - gamma
+        self.gamma = nn.Parameter(torch.Tensor([initial_gamma]))
+
+        # learnable 'xmax' - beta
+        self.beta = nn.Parameter(torch.Tensor([0.0]))
+
+
+        self.fake_beta=None
+        self.fake_gamma=None
+
+    def forward(self, x):
+        if self.training:
+            self.fake_beta,self.fake_gamma=_const_quan(self.beta,self.gamma)
+            x = x - self.fake_beta
+            e_x = torch.exp(x)
+            return e_x / self.fake_gamma
+        else:
+            scale_beta=100
+            scale_gamma=10
+            x = x - dequantize(quantize(self.beta,scale_beta),scale_beta)
+            e_x = torch.exp(x)
+            return e_x/dequantize(quantize(self.gamma,scale_gamma),scale_gamma)
+
 # Softmax with learnable parameters for xmax and denominator
 class Constantmax(nn.Module):
     """ Softmax with learnable parameters for xmax and denominator """
@@ -279,6 +334,10 @@ class CausalSelfAttention(nn.Module):
               self.constantmax_constant = config.constantmax_constant
               self.softmax_layer = Constantmax()
 
+            if self.softmax_variant == "constantmax_quan":
+                self.use_softermax_xmax = config.use_softermax_xmax
+                self.softmax_layer = Constantmax_quan()
+
             if self.softmax_variant == "strongermax":
               self.use_softermax_xmax = config.use_softermax_xmax
               self.softmax_layer = Strongermax(subtract_max=self.use_softermax_xmax,strength=config.strongermax_strength)
@@ -453,6 +512,10 @@ class GPT(nn.Module):
               self.use_softermax_xmax = config.use_softermax_xmax
               self.constantmax_constant = config.constantmax_constant
               self.softmax_layer = Constantmax()
+
+            if self.softmax_variant == "constantmax_quan":
+                self.use_softermax_xmax = config.use_softermax_xmax
+                self.softmax_layer = Constantmax_quan()
 
             if self.softmax_variant == "strongermax":
               self.use_softermax_xmax = config.use_softermax_xmax

--- a/model.py
+++ b/model.py
@@ -52,21 +52,23 @@ class Softermax(nn.Module):
         e_x = torch.pow(2.0, x)
         return e_x / e_x.sum(dim=self.dim, keepdim=True)
 
-# Softmax base 2, with constant denominator, and option to remove max subtraction
+# Softmax with learnable parameters for xmax and denominator
 class Constantmax(nn.Module):
-    """ Base-2 Softmax with option to remove max subtraction"""
-    def __init__(self, dim=-1, subtract_max=True, constant=1000):
+    """ Softmax with learnable parameters for xmax and denominator """
+    def __init__(self, dim=-1, initial_gamma=500):
         super().__init__()
         self.dim = dim
-        self.subtract_max = subtract_max
-        self.constant = constant
+
+        # learnable 'xmax' - beta
+        self.beta = nn.Parameter(torch.Tensor([0.0]))
+
+        # denominator - gamma
+        self.gamma = nn.Parameter(torch.Tensor([initial_gamma]))
 
     def forward(self, x):
-        if self.subtract_max:
-            max_x = x.max(dim=self.dim, keepdim=True).values
-            x = x - max_x
-        e_x = torch.pow(2.0, x)
-        return e_x / self.constant
+        x = x - self.beta
+        e_x = torch.exp(x)
+        return e_x / self.gamma
 
 # Like softermax, but parameterized to permit exploration of bases greater than 2
 class Strongermax(nn.Module):
@@ -275,7 +277,7 @@ class CausalSelfAttention(nn.Module):
             if self.softmax_variant == "constantmax":
               self.use_softermax_xmax = config.use_softermax_xmax
               self.constantmax_constant = config.constantmax_constant
-              self.softmax_layer = Constantmax(subtract_max=self.use_softermax_xmax, constant=self.constantmax_constant)
+              self.softmax_layer = Constantmax()
 
             if self.softmax_variant == "strongermax":
               self.use_softermax_xmax = config.use_softermax_xmax
@@ -440,7 +442,7 @@ class GPT(nn.Module):
             if self.softmax_variant == "constantmax":
               self.use_softermax_xmax = config.use_softermax_xmax
               self.constantmax_constant = config.constantmax_constant
-              self.softmax_layer = Constantmax(subtract_max=self.use_softermax_xmax, constant=self.constantmax_constant)
+              self.softmax_layer = Constantmax()
 
             if self.softmax_variant == "strongermax":
               self.use_softermax_xmax = config.use_softermax_xmax

--- a/model.py
+++ b/model.py
@@ -53,6 +53,7 @@ class Softermax(nn.Module):
         return e_x / e_x.sum(dim=self.dim, keepdim=True)
 
 # Softmax base 2, with constant denominator, and option to remove max subtraction
+#poor man's easiest quantization
 def quantize(tensor,scale):
     tensor = tensor.mul(scale)
     tensor = torch.round(tensor)
@@ -66,8 +67,8 @@ class const_quan(torch.autograd.Function):
     @staticmethod
     def forward(ctx, beta=None, gamma=None):
         #scaling factor for beta and gamma while doing quantization
-        scale_beta=100
-        scale_gamma=10
+        scale_beta=9#scaling factor for quantization, should make it as parameter
+        scale_gamma=8
         beta = quantize(beta, scale_beta)
         gamma = quantize(gamma, scale_gamma)
         return dequantize(beta, scale_beta),dequantize(gamma,scale_gamma)
@@ -101,8 +102,8 @@ class Constantmax_quan(nn.Module):
             e_x = torch.exp(x)
             return e_x / self.fake_gamma
         else:
-            scale_beta=100
-            scale_gamma=10
+            scale_beta=9 #scaling factor for quantization, should make it as parameter
+            scale_gamma=8
             x = x - dequantize(quantize(self.beta,scale_beta),scale_beta)
             e_x = torch.exp(x)
             return e_x/dequantize(quantize(self.gamma,scale_gamma),scale_gamma)

--- a/train.py
+++ b/train.py
@@ -50,6 +50,7 @@ def parse_args():
     model_group.add_argument('--n_embd', default=384, type=int)
     model_group.add_argument('--dropout', default=0.2, type=float)
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument('--use_post_ln', default=False, action=argparse.BooleanOptionalAction)
 
     # Norm variations
     model_group.add_argument('--use_rmsnorm', default=True, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -63,7 +63,7 @@ def parse_args():
 
     # Softmax variations
     model_group.add_argument('--use_softmax_variant', default=False, action=argparse.BooleanOptionalAction)
-    model_group.add_argument("--softmax_variant", type=str, default="softermax", choices=["constantmax", "polymax", "strongermax", "softermax", "sigsoftmax", "sigsoftmax_base2"])
+    model_group.add_argument("--softmax_variant", type=str, default="softermax", choices=["constantmax_quan", "constantmax", "polymax", "strongermax", "softermax", "sigsoftmax", "sigsoftmax_base2"])
 
     # Custom Softmax Variation Options
     model_group.add_argument('--use_softermax_xmax', default=False, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -62,7 +62,7 @@ def parse_args():
 
     # Softmax variations
     model_group.add_argument('--use_softmax_variant', default=False, action=argparse.BooleanOptionalAction)
-    model_group.add_argument("--softmax_variant", type=str, default="softermax", choices=["polymax", "strongermax", "softermax", "sigsoftmax", "sigsoftmax_base2"])
+    model_group.add_argument("--softmax_variant", type=str, default="softermax", choices=["constantmax", "polymax", "strongermax", "softermax", "sigsoftmax", "sigsoftmax_base2"])
 
     # Custom Softmax Variation Options
     model_group.add_argument('--use_softermax_xmax', default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
Reordered the commits of #46 on top of the commits of #51 using `git cherry-pick`, and manually resolved merge conflicts.

This retains authorship and allows us to keep the existing commit history from #46, see the following screenshot from the 'commits' tab:

![image](https://github.com/ReaLLMASIC/nanoGPT/assets/10952473/dd14ac35-6877-48da-a55b-a8519de94bb8)

@advancedengineering This PR is built on top of #50 and #51, and if this looks good, let's merge in this order:

first #50, then #51, finally #52

Let me know if this looks okay, then we'll have everything merged in soon : )