### PR TITLE
Add Scripts Compatible with the Open Math Instruct 1 Dataset

### DIFF
--- a/data/open_math_instruct_1/README.md
+++ b/data/open_math_instruct_1/README.md
@@ -18,7 +18,7 @@ The `OpenMathInstruct-1` dataset comprises several fields as outlined below:
 - `dataset`: Specifies the source dataset for the question, which can be either `gsm8k` or `math`.
 - `generation_type`: Denotes the method used for generating the solution, categorized as either `without_reference_solution` or `masked_reference_solution`.
 
-## Download
+## Download Dataset
 
 Run the get datasets script to download the data
 
@@ -26,8 +26,23 @@ Run the get datasets script to download the data
 bash get_datasets.sh
 ```
 
-Then run the prepare.py script with preferred tokenization to create the
-train.bin and val.bin for training.
+The above will create `train.txt` and `validation.txt` files ready for
+tokenization.
+
+## Tokenizate files
+
+Finally run the `prepare.py` script on the separate files to permit creation of
+the train.bin and validation.bin files needed for training.
+
+For example for tiktoken:
+```sh
+python3 prepare.py -s -t train.txt -v validation.txt
+```
+
+Or for sentence piece (warning requires *a lot* of ram):
+```sh
+python3 prepare.py -s -t train.txt -v validation.txt --method sentencepiece
+```
 
 ## Reference and more information
 

--- a/data/open_math_instruct_1/README.md
+++ b/data/open_math_instruct_1/README.md
@@ -1,0 +1,67 @@
+# Open Math Instruct 1
+
+This is a dataset created with the permissive
+[Mistral-8x7B](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1) model.
+
+It aims to improve mathematics capabilities of the model.
+
+## Description
+
+The `OpenMathInstruct-1` dataset comprises several fields as outlined below:
+
+- `question`: The original question sourced from either the GSM8K or MATH training set.
+- `generated_solution`: This field contains a synthetically generated solution that incorporates both textual reasoning and code blocks.
+- `expected_answer`: The original dataset's provided ground-truth answer.
+- `predicted_answer`: The answer predicted by the Mixtral model within the generated solution, typically extracted from `\boxed{}` notation.
+- `error_message`: This field captures error states; it is set to `<not_executed>` if code execution was not required. Otherwise, it may be empty or contain a Python exception message from the evaluated code block. A "timeout" message indicates that the code block's execution exceeded 10 seconds, leading to an automatic halt of generation for any error or timeout occurrences.
+- `is_correct`: Indicates whether the generated solution's final answer was deemed correct according to our grading script.
+- `dataset`: Specifies the source dataset for the question, which can be either `gsm8k` or `math`.
+- `generation_type`: Denotes the method used for generating the solution, categorized as either `without_reference_solution` or `masked_reference_solution`.
+
+## Download
+
+Run the get datasets script to download the data
+
+```sh
+bash get_datasets.sh
+```
+
+Then run the prepare.py script with preferred tokenization to create the
+train.bin and val.bin for training.
+
+## Reference and more information
+
+- https://huggingface.co/datasets/nvidia/OpenMathInstruct-1
+- https://github.com/Kipok/NeMo-Skills/tree/main
+- [Arxiv Paper: OpenMathInstruct-1: A 1.8 Million Math Instruction Tuning Dataset](https://arxiv.org/abs/2402.10176)
+
+## Full text of dataset license
+
+```
+NVIDIA License
+
+1. Definitions
+
+“Licensor” means any person or entity that distributes its Work.
+“Work” means (a) the original work of authorship made available under this license, which may include software, documentation, or other files, and (b) any additions to or derivative works thereof that are made available under this license.
+The terms “reproduce,” “reproduction,” “derivative works,” and “distribution” have the meaning as provided under U.S. copyright law; provided, however, that for the purposes of this license, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work.
+Works are “made available” under this license by including in or with the Work either (a) a copyright notice referencing the applicability of this license to the Work, or (b) a copy of this license.
+
+2. License Grant. Copyright Grant. Subject to the terms and conditions of this license, each Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free, copyright license to use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense and distribute its Work and any resulting derivative works in any form.
+
+3. Limitations
+
+3.1 Redistribution. You may reproduce or distribute the Work only if (a) you do so under this license, (b) you include a complete copy of this license with your distribution, and (c) you retain without modification any copyright, patent, trademark, or attribution notices that are present in the Work.
+
+3.2 Derivative Works. You may specify that additional or different terms apply to the use, reproduction, and distribution of your derivative works of the Work (“Your Terms”) only if (a) Your Terms provide that the use limitation in Section 3.3 applies to your derivative works, and (b) you identify the specific derivative works that are subject to Your Terms. Notwithstanding Your Terms, this license (including the redistribution requirements in Section 3.1) will continue to apply to the Work itself.
+
+3.3 Patent Claims. If you bring or threaten to bring a patent claim against any Licensor (including any claim, cross-claim or counterclaim in a lawsuit) to enforce any patents that you allege are infringed by any Work, then your rights under this license from such Licensor (including the grant in Section 2.1) will terminate immediately.
+
+3.4 Trademarks. This license does not grant any rights to use any Licensor’s or its affiliates’ names, logos, or trademarks, except as necessary to reproduce the notices described in this license.
+
+3.5 Termination. If you violate any term of this license, then your rights under this license (including the grant in Section 2.1) will terminate immediately.
+
+4. Disclaimer of Warranty. THE WORK IS PROVIDED “AS IS” WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OR CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NON-INFRINGEMENT. YOU BEAR THE RISK OF UNDERTAKING ANY ACTIVITIES UNDER THIS LICENSE. 
+
+5. Limitation of Liability. EXCEPT AS PROHIBITED BY APPLICABLE LAW, IN NO EVENT AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE SHALL ANY LICENSOR BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATED TO THIS LICENSE, THE USE OR INABILITY TO USE THE WORK (INCLUDING BUT NOT LIMITED TO LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOST PROFITS OR DATA, COMPUTER FAILURE OR MALFUNCTION, OR ANY OTHER DAMAGES OR LOSSES), EVEN IF THE LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+```

--- a/data/open_math_instruct_1/get_dataset.sh
+++ b/data/open_math_instruct_1/get_dataset.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+wget -O trian.jsonl https://huggingface.co/datasets/nvidia/OpenMathInstruct-1/resolve/main/correct_solutions/train.jsonl?download=true
+wget -O validation.jsonl https://huggingface.co/datasets/nvidia/OpenMathInstruct-1/resolve/main/correct_solutions/validation.jsonl?download=true
+
+python3 jsonl_to_txt.py validation.jsonl validation.txt
+python3 jsonl_to_txt.py train.jsonl train.txt
+
+echo "Next step is to tokenize using the separate files."
+echo "For example, with tiktoken:"
+echo "python3 prepare.py -s -t train.txt -v validation.txt"
+

--- a/data/open_math_instruct_1/jsonl_to_txt.py
+++ b/data/open_math_instruct_1/jsonl_to_txt.py
@@ -1,0 +1,35 @@
+import argparse
+import json
+
+def parseargs():
+    parser = argparse.ArgumentParser(description='Extract questions and answers from a JSONL file.')
+    parser.add_argument('input_file', type=str, help='path to input jsonl file')
+    parser.add_argument('output_file', type=str, help='Path to output txt file')
+
+    return parser.parse_args()
+
+# Function to extract and format data from each JSON object in the .jsonl file
+def extract_and_format_data(file_path):
+    formatted_data_list = []
+    with open(file_path, 'r') as file:
+        for line in file:
+            data_dict = json.loads(line)
+            question = data_dict.get("question", "")
+            expected_answer = data_dict.get("expected_answer", "")
+            formatted_data = f"question: {question}\nanswer: {expected_answer}\n"
+            formatted_data_list.append(formatted_data)
+    return formatted_data_list
+
+# Write the extracted and formatted data to a text file
+def write_to_file(formatted_data_list, output_file):
+    with open(output_file, "w") as file:
+        for formatted_data in formatted_data_list:
+            file.write(formatted_data + "\n")  # Add an extra newline for separation between entries
+
+# Main script execution
+if __name__ == "__main__":
+    args = parseargs()
+    formatted_data_list = extract_and_format_data(args.input_file)
+    write_to_file(formatted_data_list, args.output_file)
+    print(f"Data has been extracted and saved to '{args.output_file}'.")
+

--- a/data/open_math_instruct_1/prepare.py
+++ b/data/open_math_instruct_1/prepare.py
@@ -1,0 +1,182 @@
+import os
+import argparse
+import numpy as np
+import pickle
+import sentencepiece as spm
+import tiktoken
+
+
+def train_sentencepiece_model(input_files, model_prefix, vocab_size):
+    """Train a SentencePiece model."""
+
+    # Other options (https://github.com/google/sentencepiece/blob/master/doc/options.md)
+    # self_test_sample_size=1,
+    # input_format="text",
+    # shuffle_input_sentence = false
+    # split_digits=False, # this often helps with arithmetic
+    # allow_whitespace_only_pieces=True,
+    # normalization_rule_name="nmt_nfkc_cf" lower cases as well
+    num_threads = os.cpu_count()
+    input_arg = ",".join(input_files) if isinstance(input_files, list) else input_files
+    spm.SentencePieceTrainer.train(
+        num_threads=num_threads,
+        input=input_arg,
+        model_prefix=model_prefix,
+        vocab_size=vocab_size,
+        model_type="bpe",
+    )
+    print("SentencePiece model training complete.")
+
+
+def tokenize_sentencepiece(sp_model, data):
+    """Tokenize data using the SentencePiece model."""
+    return sp_model.encode_as_ids(data)
+
+
+def tokenize_tiktoken(enc, data):
+    """Tokenize data using TikToken."""
+    return enc.encode_ordinary(data)
+
+
+def encode_char_level(data, chars):
+    """Encode data at character level."""
+    stoi = {ch: i for i, ch in enumerate(chars)}
+    return [stoi[ch] for ch in data], stoi, {i: ch for i, ch in enumerate(chars)}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Tokenize text data using different methods."
+    )
+
+    # Default option is a single input file
+    parser.add_argument('-i', "--input_file", type=str, help="Path to the input text file")
+
+    parser.add_argument(
+        "--method",
+        type=str,
+        choices=["sentencepiece", "tiktoken", "char"],
+        default="tiktoken",
+        help="Tokenization method",
+    )
+
+    # Sentence Piece only argument
+    parser.add_argument(
+        "--vocab_size",
+        type=int,
+        default=500,
+        help="Vocabulary size for SentencePiece model",
+    )
+
+    # Customize output names for bins
+    parser.add_argument(
+        "--train_output",
+        type=str,
+        default="train.bin",
+        help="Output file for tokenized training data",
+    )
+    parser.add_argument(
+        "--val_output",
+        type=str,
+        default="val.bin",
+        help="Output file for tokenized validation data",
+    )
+
+    # Options for using separate training and validation input files
+    parser.add_argument(
+        "-s",
+        "--use_separate_files",
+        action="store_true",
+        help="Use separate files for training and validation input",
+    )
+    parser.add_argument(
+        "-t", "--train_input", type=str, help="Path to the training input text file"
+    )
+    parser.add_argument(
+        "-v", "--val_input", type=str, help="Path to the validation input text file"
+    )
+
+    args = parser.parse_args()
+
+    if args.use_separate_files:
+        if not args.train_input or not args.val_input:
+            raise ValueError(
+                "Both --train_input and --val_input must be provided when using --use_separate_files."
+            )
+        input_files = [args.train_input, args.val_input]
+    else:
+        if not args.train_input:
+            raise ValueError(
+                "You must provide --train_input when not using --use_separate_files."
+            )
+        input_files = args.train_input
+
+    # Read data
+    if args.use_separate_files:
+        with open(args.train_input, "r") as f:
+            train_data = f.read()
+        with open(args.val_input, "r") as f:
+            val_data = f.read()
+    else:
+        with open(args.train_input, "r") as f:
+            data = f.read()
+        n = len(data)
+        train_data = data[: int(n * 0.9)]
+        val_data = data[int(n * 0.9) :]
+
+    if args.method == "sentencepiece":
+        # Train and use SentencePiece
+        spm_model_prefix = os.path.splitext(args.input_file)[0] + "_spm_model"
+        train_sentencepiece_model(input_files, spm_model_prefix, args.vocab_size)
+        sp = spm.SentencePieceProcessor()
+        sp.load(f"{spm_model_prefix}.model")
+        train_ids = tokenize_sentencepiece(sp, train_data)
+        val_ids = tokenize_sentencepiece(sp, val_data)
+
+        # Create stoi (string-to-index) and itos (index-to-string) mappings
+        stoi = {sp.id_to_piece(id): id for id in range(sp.GetPieceSize())}
+        itos = {id: sp.id_to_piece(id) for id in range(sp.GetPieceSize())}
+
+        # Manually add newline character to vocab
+        if "\n" not in stoi:
+            stoi["\n"] = sp.PieceToId("\n")
+
+        # Save metadata including stoi and itos in a pickle file
+        meta = {"vocab_size": sp.GetPieceSize(), "stoi": stoi, "itos": itos}
+        with open(os.path.join(os.path.dirname(__file__), "meta.pkl"), "wb") as f:
+            pickle.dump(meta, f)
+
+    elif args.method == "tiktoken":
+        # Use TikToken
+        enc = tiktoken.get_encoding("gpt2")
+        train_ids = tokenize_tiktoken(enc, train_data)
+        val_ids = tokenize_tiktoken(enc, val_data)
+
+    elif args.method == "char":
+        # Print the total length of the dataset in characters
+        print(f"Length of dataset in characters: {len(data):,}")
+        # Character-level tokenization
+        chars = sorted(
+            list(set(train_data + val_data))
+        )  # Get unique characters in train data
+        vocab_size = len(chars)
+        print("All unique characters:", "".join(chars))
+        print(f"Vocab size: {vocab_size}")
+
+        train_ids, stoi, itos = encode_char_level(train_data, chars)
+        val_ids, _, _ = encode_char_level(val_data, chars)
+
+        # Save the meta information
+        meta = {"vocab_size": vocab_size, "itos": itos, "stoi": stoi}
+        with open(os.path.join(os.path.dirname(__file__), "meta.pkl"), "wb") as f:
+            pickle.dump(meta, f)
+
+    # Print token counts and export to bin files
+    print(f"train has {len(train_ids):,} tokens")
+    print(f"val has {len(val_ids):,} tokens")
+    np.array(train_ids, dtype=np.uint16).tofile(args.train_output)
+    np.array(val_ids, dtype=np.uint16).tofile(args.val_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/open_math_instruct_1/txt_to_phonemes.sh
+++ b/data/open_math_instruct_1/txt_to_phonemes.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Function to display help menu
+show_help() {
+    echo "Usage: $0 [options] input_file output_file"
+    echo
+    echo "Options:"
+    echo "  -h            Display this help message and exit."
+    echo "  -n <number>   Set the number of cores to use. Defaults to all cores."
+    echo
+    echo "Example:"
+    echo "  $0 -n 4 input.txt output.txt"
+    echo
+    echo "This script reads from an input file, processes each line, and writes the output to an output file."
+}
+
+# Default number of cores to use
+num_cores=""
+
+# Parse command-line options
+while getopts ":hn:" opt; do
+    case ${opt} in
+        h )
+            show_help
+            exit 0
+            ;;
+        n )
+            num_cores="-j ${OPTARG}"
+            ;;
+        \? )
+            echo "Invalid option: $OPTARG" 1>&2
+            exit 1
+            ;;
+        : )
+            echo "Invalid option: $OPTARG requires an argument" 1>&2
+            exit 1
+            ;;
+    esac
+done
+
+# Remove the options processed above
+shift $((OPTIND -1))
+
+# Check if the correct number of arguments is given after option processing
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 [options] input_file output_file"
+    exit 1
+fi
+
+# Assign input and output file from arguments
+input_file=$1
+output_file=$2
+
+# Check if input file exists
+if [ ! -f "$input_file" ]; then
+    echo "Input file does not exist"
+    exit 1
+fi
+
+# Function to process a line
+process_line() {
+    line="$1"
+    echo "$line" | espeak -q -x
+}
+
+# Export the function to be used by parallel
+export -f process_line
+
+# Use GNU Parallel to process the lines using specified number of cores
+cat "$input_file" | parallel $num_cores -k process_line >> "$output_file"
+

--- a/data/wikitext103/get_wikitext103.py
+++ b/data/wikitext103/get_wikitext103.py
@@ -1,22 +1,72 @@
-import torchtext
-from torchtext.datasets import WikiText103
+import os
+import requests
+import argparse
+import json
 
 
-def download_wikitext103():
-    # Define the dataset path
-    dataset_path = '.data'
+def download_file(url, filename):
+    """
+    Download a file from a given URL.
+    """
+    response = requests.get(url)
+    response.raise_for_status()  # Ensure the download was successful.
+    with open(filename, "wb") as f:
+        f.write(response.content)
+    print(f"Downloaded {filename}")
 
-    # Download the WikiText-103 dataset
-    train_iter, valid_iter, test_iter = WikiText103(root=dataset_path,
-                                                    split=('train', 'valid',
-                                                           'test'))
 
-    # Open a file to save the dataset
-    with open('wikitext103.txt', 'w') as file:
-        for dataset in [train_iter, valid_iter, test_iter]:
-            for line in dataset:
-                file.write(line + '\n')
+def main(output_text_file):
+    parquet_files = {
+        "train-00000-of-00002": "https://huggingface.co/datasets/wikitext/resolve/main/wikitext-103-v1/train-00000-of-00002.parquet?download=true",
+        "train-00001-of-00002": "https://huggingface.co/datasets/wikitext/resolve/main/wikitext-103-v1/train-00001-of-00002.parquet?download=true",
+        "validation-00000-of-00001": "https://huggingface.co/datasets/wikitext/resolve/main/wikitext-103-v1/validation-00000-of-00001.parquet?download=true",
+        "test-00000-of-00001": "https://huggingface.co/datasets/wikitext/resolve/main/wikitext-103-v1/test-00000-of-00001.parquet?download=true"
+    }
+
+    download_dir = "./downloaded_parquets"
+    json_dir = "./json_output"
+
+    os.makedirs(download_dir, exist_ok=True)
+    os.makedirs(json_dir, exist_ok=True)
+
+    if output_text_file:
+        # Ensure the output text file is empty before starting
+        open(output_text_file, "w").close()
+
+    for file_name, url in parquet_files.items():
+        parquet_path = os.path.join(download_dir, file_name + ".parquet")
+        json_path = os.path.join(json_dir, file_name + ".json")
+
+        if not os.path.exists(parquet_path):
+            # Download the Parquet file only if it doesn't exist locally
+            download_file(url, parquet_path)
+
+        # Convert Parquet file to JSON (if needed, can be skipped)
+        # This step can be omitted if you're directly working with Parquet files
+        # Convert the Parquet file to JSON
+        # convert_to_json(parquet_path, json_path)
+
+        with open(json_path, "r") as f:
+            data = json.load(f)
+
+        with open(output_text_file, "a") as f:
+            for item in data:
+                f.write(item["text"].strip() + '\n')
 
 
 if __name__ == "__main__":
-    download_wikitext103()
+    parser = argparse.ArgumentParser(
+        description="Print text values from JSON files to a text file."
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output_text_file",
+        type=str,
+        default="input.txt",
+        help="Path to the output text file where the contents should be saved."
+    )
+
+    args = parser.parse_args()
+    main(args.output_text_file)
+


### PR DESCRIPTION
# Adding Scripts Compatible with the Open Math Instruct 1 Dataset

View the the Open Math Instruct 1 paper at the following link:

https://arxiv.org/abs/2402.10176

## Prepare.py updates
For this dataset, needed to add a feature to prepare.py to handle separate train and validation files (to map train.txt to train.bin and validation.txt to val.bin). Also updated the main template with these as they may come in handy on other datasets as well.

## Wikitext103 download script fixes 

Bundled in this PR is also a fix for the wikitext103 download script.