### PR TITLE
Add options for sharing MLP or sharing attention weights across layers

### DIFF
--- a/train.py
+++ b/train.py
@@ -56,6 +56,7 @@ def parse_args():
 
     # Shared Parameter Settings
     model_group.add_argument('--sharing_mlp', default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument('--sharing_attn', default=False, action=argparse.BooleanOptionalAction)
 
     # NORM VARIATIONS
     model_group.add_argument("--layernorm_variant", type=str, default="rmsnorm", choices=["rmsnorm", "layernorm"])

--- a/train.py
+++ b/train.py
@@ -54,6 +54,9 @@ def parse_args():
     model_group.add_argument('--dropout', default=0.2, type=float)
     model_group.add_argument('--use_post_ln', default=True, action=argparse.BooleanOptionalAction)
 
+    # Shared Parameter Settings
+    model_group.add_argument('--sharing_mlp', default=False, action=argparse.BooleanOptionalAction)
+
     # NORM VARIATIONS
     model_group.add_argument("--layernorm_variant", type=str, default="rmsnorm", choices=["rmsnorm", "layernorm"])
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")


### PR DESCRIPTION
This is discussed in both [ALBERT](https://arxiv.org/abs/1909.11942) and recently in [MobiLlama](https://arxiv.org/abs/2402.16840).

From early experiments it appears to indeed yield a lot more performance per parameter, and it is very simple to implement.

Note also means we can train larger models (n_embd, n_layers, context length) with the same compute.