### PR TITLE
Template Config for Swapping Out Different Datasets

### DIFF
--- a/curriculum/curriculum.json
+++ b/curriculum/curriculum.json
@@ -2,7 +2,7 @@
     {
       "config": "template.json", 
       "max_iters": 3000,
-      "dataset": "shakespeare_char",
+      "dataset": "openwebtext",
       "block_size": 256
     },
     {

--- a/curriculum/curriculum.json
+++ b/curriculum/curriculum.json
@@ -1,0 +1,32 @@
+[
+    {
+      "config": "template.json", 
+      "max_iters": 3000,
+      "dataset": "shakespeare_char",
+      "block_size": 256
+    },
+    {
+      "config": "template.json", 
+      "max_iters": 3000,
+      "dataset": "wikitext103",
+      "block_size": 256
+    },
+    {
+      "config": "template.json", 
+      "max_iters": 3000,
+      "dataset": "xsum",
+      "block_size": 256
+    },
+    {
+      "config": "template.json", 
+      "max_iters": 3000,
+      "dataset": "billsum",
+      "block_size": 256
+    },
+    {
+      "config": "template.json", 
+      "max_iters": 3000,
+      "dataset": "cnn_dailymail",
+      "block_size": 256
+    }
+]

--- a/explorations/template.json
+++ b/explorations/template.json
@@ -1,0 +1,28 @@
+[
+    {
+        "max_iters": ["3000"],
+        "n_layer": ["6"],
+        "n_head": ["6"],
+        "n_embd": ["384"],
+        "block_size": ["256"],
+        "eval_iters": ["200"],
+        "eval_interval": ["250"],
+        "log_interval": ["10"],
+        "device": ["cuda"],
+        "dataset": [""],
+        "compile": [true],
+         "seed": {
+          "range": {
+            "start": 1,
+            "end": 5,
+            "step": 1
+          }
+        },
+        "use_post_ln": [true],
+        "softmax_variant_attn": ["softmax"],
+        "use_abs_pos_embeddings": [true],
+        "use_rotary_embeddings": [true],
+        "tensorboard_run_name": ["curriculum"]
+    }
+]
+


### PR DESCRIPTION
For curriculum learning, we wanted a more dynamic way of modifying the training parameters. Thus, we wanted to create a template json file where we can override values for the max iteration number, dataset, and context length, without changing the overall architecture. 

Changes:
-Added a curriculum/curriculum.json file that allows users to run curriculum learning with the template json file and manual modifying of the training parameters
-Updated run_curriculum_learning.py to work with json inputs and call run_experiments with the manually modified training parameters
-Added 'override_max_iters', 'override_dataset', and 'override_block_size' arguments to run_experiments.py, which allow for direct overriding of the respective config values