### PR TITLE
Add support for experimental layernorm variations

### DIFF
--- a/explorations/norm_sweep.json
+++ b/explorations/norm_sweep.json
@@ -1,0 +1,21 @@
+[
+    {
+      "max_iters": ["3500"],
+      "n_layer": ["6"],
+      "n_head": ["6"],
+      "n_embd": ["384"],
+      "block_size":["256"],
+      "use_post_ln": [true, false],
+      "device": ["cuda"],
+      "dtype": ["bfloat16"],
+      "dataset": ["shakespeare_char"],
+      "use_rotary_embeddings": [true],
+      "use_abs_pos_embeddings": [true],
+      "compile": [false],
+      "softmax_variant_attn": ["softmax", "polymax"],
+      "layernorm_variant": ["batchnorm", "layernorm", "rmsnorm", "powernorm", "groupnorm", "instancenorm"],
+      "layernorm_variant_output": ["layernorm", "rmsnorm"],
+      "tensorboard_run_name": ["new_norms"]
+    }
+  ]
+

--- a/train.py
+++ b/train.py
@@ -66,7 +66,8 @@ def parse_args():
     model_group.add_argument('--shared_attn_sym', default=False, action=argparse.BooleanOptionalAction, help="symmetrical attention sharing")
 
     # NORM VARIATIONS
-    model_group.add_argument("--layernorm_variant", type=str, default="rmsnorm", choices=["rmsnorm", "layernorm"])
+    model_group.add_argument("--layernorm_variant", type=str, default="rmsnorm", choices=["rmsnorm", "layernorm","powernorm", "groupnorm", "instancenorm", "batchnorm"])
+    model_group.add_argument("--layernorm_variant_output", type=str, default="rmsnorm", choices=["rmsnorm", "layernorm","powernorm", "groupnorm", "instancenorm", "batchnorm"])
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
 
     # ACTIVATION VARIATIONS

--- a/variations/normalization_variations.py
+++ b/variations/normalization_variations.py
@@ -3,8 +3,9 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
+
 class LayerNorm(nn.Module):
-    """ LayerNorm but with an optional bias. PyTorch doesn't support simply bias=False """
+    """LayerNorm but with an optional bias. PyTorch doesn't support simply bias=False"""
 
     def __init__(self, ndim, bias):
         super().__init__()
@@ -13,6 +14,7 @@ class LayerNorm(nn.Module):
 
     def forward(self, input):
         return F.layer_norm(input, self.weight.shape, self.weight, self.bias, 1e-5)
+
 
 class RMSNorm(nn.Module):
     """RMS Normalization"""
@@ -25,3 +27,57 @@ class RMSNorm(nn.Module):
         rms = x.norm(2, dim=-1, keepdim=True) / math.sqrt(x.size(-1))
         return x / rms * self.gain
 
+
+class PowerNorm(nn.Module):
+    """Power Normalization"""
+
+    def __init__(self, ndim, alpha=0.5):
+        super().__init__()
+        self.alpha = alpha
+        self.gain = nn.Parameter(torch.ones(ndim))
+
+    def forward(self, x):
+        mean = x.mean(dim=-1, keepdim=True)
+        var = x.var(dim=-1, keepdim=True)
+        normalized = (x - mean) / torch.pow(var + 1e-5, self.alpha)
+        return normalized * self.gain
+
+
+class GroupNorm(nn.GroupNorm):
+    """Group Normalization with gain parameter"""
+
+    def __init__(self, num_groups, num_channels, eps=1e-5):
+        super().__init__(num_groups, num_channels, eps)
+        self.gain = nn.Parameter(torch.ones(num_channels))
+
+    def forward(self, x):
+        normalized = super().forward(x)
+        return normalized * self.gain
+
+
+class InstanceNorm(nn.InstanceNorm2d):
+    """Instance Normalization with gain parameter"""
+
+    def __init__(self, num_features, eps=1e-5):
+        super().__init__(num_features, eps)
+        self.gain = nn.Parameter(torch.ones(num_features))
+
+    def forward(self, x):
+        normalized = super().forward(x)
+        return normalized * self.gain
+
+
+class BatchNorm(nn.BatchNorm1d):
+    """BatchNorm1d with gain parameter"""
+
+    def __init__(self, num_features, eps=1e-5, momentum=0.1):
+        super().__init__(num_features, eps, momentum)
+        self.gain = nn.Parameter(torch.ones(num_features))
+
+    def forward(self, x):
+        # Reshape input for BatchNorm1d
+        x = x.transpose(1, 2)
+        normalized = super().forward(x)
+        # Reshape back to original shape
+        x = normalized.transpose(1, 2)
+        return x * self.gain


### PR DESCRIPTION
This separates the output and transformer block layernorms, while allowing each to be set to (in addition to layernorm and rmsnorm):
- GroupNorm - grouped layernorm
- InstanceNorm - elementwise layernorm
- BatchNorm - norm across batches in training, elementwise in inference
- PowerNorm - no hardware advantages but might offer better val loss