### PR TITLE
Add linear variations

### DIFF
--- a/explorations/linear_sweep.json
+++ b/explorations/linear_sweep.json
@@ -11,7 +11,7 @@
       "device": ["cuda"],
       "dtype": ["float16"],
       "dataset": ["shakespeare_char"],
-      "linear_variant": ["bitlinear", "bitlinear_optimized", "linear"],
+      "linear_variant": ["bitlinear_1p58", "bitlinear", "bitlinear_optimized", "linear"],
       "compile": [true],
       "softmax_variant_attn": ["softmax", "polymax"],
       "tensorboard_run_name": ["linear_variation_sweep"]

--- a/explorations/linear_sweep.json
+++ b/explorations/linear_sweep.json
@@ -1,0 +1,20 @@
+[
+    {
+      "max_iters": ["100000"],
+      "n_layer": ["6"],
+      "n_kv_group": ["6"],
+      "n_head": ["6"],
+      "n_embd": ["384"],
+      "block_size":["256"],
+      "eval_interval": ["250"],
+      "patience": ["10"],
+      "device": ["cuda"],
+      "dtype": ["float16"],
+      "dataset": ["shakespeare_char"],
+      "linear_variant": ["bitlinear", "bitlinear_optimized", "linear"],
+      "compile": [true],
+      "softmax_variant_attn": ["softmax", "polymax"],
+      "tensorboard_run_name": ["linear_variation_sweep"]
+    }
+  ]
+

--- a/model.py
+++ b/model.py
@@ -357,8 +357,8 @@ class GPTConfig:
     exppolymax_divisor: float = 1.0
 
     # Positional Embeddings Variations
-    use_abs_pos_embeddings: bool = False # Note: one can use this AND rotary embeddings
-    use_rotary_embeddings: bool = True # If True, uses rotary embeddings, else use conventional absolute position encoding
+    use_abs_pos_embeddings: bool = True # Note: one can use this AND rotary embeddings
+    use_rotary_embeddings: bool = False # If True, uses rotary embeddings, else use conventional absolute position encoding
     rope_variant: str = "rope" # options: "shortrope", "rope"
     shortrope_length: int = 8 # number of embeddings to use in shortrope
 

--- a/model.py
+++ b/model.py
@@ -21,7 +21,7 @@ from variations.softmax_variations import Softermax, Constantmax, Constantmax_qu
 from variations.normalization_variations import LayerNorm, RMSNorm
 from variations.position_encoding_variations import RotaryEmbedding, ShortRope, SymmetricalOverlapAngularPositions
 from variations.activation_variations import SquaredReLU, activation_dictionary
-from variations.linear_variations import BitLinear, BitLinearOptimized, linear_dictionary
+from variations.linear_variations import BitLinear1p58, BitLinear, BitLinearOptimized, linear_dictionary
 
 def create_shared_param_group(layer_type, config):
     shared_size = None

--- a/train.py
+++ b/train.py
@@ -94,6 +94,18 @@ def parse_args():
         ],
     )
 
+    # LINEAR VARIATIONS
+    model_group.add_argument(
+        "--linear_variant",
+        type=str,
+        default="linear",
+        choices=[
+            "linear",
+            "bitlinear",
+            "bitlinear_optimized",
+        ],
+    )
+
     # POSITIONAL EMBEDDING VARIATIONS
     model_group.add_argument('--use_rotary_embeddings', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--rope_variant", type=str, default="rope", choices=["shortrope", "rope"])

--- a/train.py
+++ b/train.py
@@ -102,6 +102,7 @@ def parse_args():
         choices=[
             "linear",
             "bitlinear",
+            "bitlinear_1p58",
             "bitlinear_optimized",
         ],
     )

--- a/train.py
+++ b/train.py
@@ -37,7 +37,7 @@ def parse_args():
     # Checkpoint args
     training_group.add_argument('--only_save_checkpoint_at_end', action='store_true')
     training_group.add_argument('--always_save_checkpoint', action='store_true')
-    training_group.add_argument('--patience', default=None, type=int)
+    training_group.add_argument('--patience', default=None, type=int, help="if set, will stop training if the number of evaluations since val loss was seen to decrease exceeds 'patience' setting.")
     training_group.add_argument('--init_from', default='scratch', choices=['scratch', 'prev_run', 'resume', 'gpt2*'], type=str)
     training_group.add_argument('--prev_run_ckpt', default='', type=str)
     training_group.add_argument('--csv_ckpt_dir', default='', type=str)

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -2,6 +2,12 @@ import torch
 import torch.nn as nn
 import math
 
+linear_dictionary = {
+    "linear": nn.Linear(),
+    "bitlinear": BitLinear(),
+    "bitlinear_optimized": BitLinearOptimized(),
+}
+
 
 class BitLinear(nn.Linear):
     """PyTorch BitLinear Layer

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -2,12 +2,6 @@ import torch
 import torch.nn as nn
 import math
 
-linear_dictionary = {
-    "linear": nn.Linear(),
-    "bitlinear": BitLinear(),
-    "bitlinear_optimized": BitLinearOptimized(),
-}
-
 
 class BitLinear(nn.Linear):
     """PyTorch BitLinear Layer
@@ -175,3 +169,10 @@ class BitLinearOptimized(nn.Linear):
         output = self.quantize_activations_groupwise(output)
 
         return output
+
+
+linear_dictionary = {
+    "linear": nn.Linear,
+    "bitlinear": BitLinear,
+    "bitlinear_optimized": BitLinearOptimized,
+}

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -1,57 +1,14 @@
-# # coding=utf-8
-# # Copyright 2023 Beomi (L. Junbum)
-# # Licensed under the Apache License, Version 2.0 (the "License")
-""" PyTorch BitLinear Layer."""
 import torch
 import torch.nn as nn
-
-
-class BitLinearNaive(nn.Linear):
-    def __init__(self, in_features, out_features, bias=True, num_groups=1):
-        super(BitLinearNaive, self).__init__(in_features, out_features, bias)
-        self.num_groups = num_groups
-        self.eps = 1e-5  # Small epsilon value to avoid division by zero and overflow
-
-    def binarize_weights(self):
-        alpha = self.weight.mean()
-        binarized_weights = torch.sign(self.weight - alpha)
-        return binarized_weights
-
-    def quantize_activations(self, x, b=8):
-        Q_b = 2 ** (b - 1)
-        gamma = x.abs().max()
-        quantized_x = torch.clamp(
-            x * Q_b / (gamma + self.eps), -Q_b + self.eps, Q_b - self.eps
-        )
-        return quantized_x
-
-    def scale_activations(self, x, b=8):
-        Q_b = 2 ** (b - 1)
-        eta = x.min()
-        gamma = x.abs().max()
-        scaled_x = torch.clamp(
-            (x - eta) * Q_b / (gamma + self.eps), self.eps, Q_b - self.eps
-        )
-        return scaled_x
-
-    def forward(self, input):
-        # Binarize weights
-        binarized_weights = self.binarize_weights()
-
-        # Normal linear transformation with binarized weights
-        output = torch.nn.functional.linear(input, binarized_weights, self.bias)
-
-        # Quantize activations (before non-linear functions like ReLU)
-        output = self.quantize_activations(output)
-
-        # For the sake of demonstration, we'll also include the scaling step.
-        # In practice, this would be done before a non-linear function in a forward pass.
-        output = self.scale_activations(output)
-
-        return output
+import math
 
 
 class BitLinear(nn.Linear):
+    """PyTorch BitLinear Layer
+    Source: https://github.com/Beomi/BitNet-Transformers/tree/main
+    Source License: Apache Version 2.0
+    """
+
     def __init__(self, in_features, out_features, bias=True, num_groups=1):
         super(BitLinear, self).__init__(in_features, out_features, bias)
         self.num_groups = num_groups
@@ -118,6 +75,11 @@ class BitLinear(nn.Linear):
 
 
 class BitLinearOptimized(nn.Linear):
+    """Memory Optimized BitLinear Layer
+    Source: https://github.com/Beomi/BitNet-Transformers/tree/main
+    Source License: Apache Version 2.0
+    """
+
     def __init__(self, in_features, out_features, bias=True, num_groups=1):
         super(BitLinearOptimized, self).__init__(in_features, out_features, bias)
         self.num_groups = num_groups

--- a/variations/linear_variations.py
+++ b/variations/linear_variations.py
@@ -1,0 +1,209 @@
+# # coding=utf-8
+# # Copyright 2023 Beomi (L. Junbum)
+# # Licensed under the Apache License, Version 2.0 (the "License")
+""" PyTorch BitLinear Layer."""
+import torch
+import torch.nn as nn
+
+
+class BitLinearNaive(nn.Linear):
+    def __init__(self, in_features, out_features, bias=True, num_groups=1):
+        super(BitLinearNaive, self).__init__(in_features, out_features, bias)
+        self.num_groups = num_groups
+        self.eps = 1e-5  # Small epsilon value to avoid division by zero and overflow
+
+    def binarize_weights(self):
+        alpha = self.weight.mean()
+        binarized_weights = torch.sign(self.weight - alpha)
+        return binarized_weights
+
+    def quantize_activations(self, x, b=8):
+        Q_b = 2 ** (b - 1)
+        gamma = x.abs().max()
+        quantized_x = torch.clamp(
+            x * Q_b / (gamma + self.eps), -Q_b + self.eps, Q_b - self.eps
+        )
+        return quantized_x
+
+    def scale_activations(self, x, b=8):
+        Q_b = 2 ** (b - 1)
+        eta = x.min()
+        gamma = x.abs().max()
+        scaled_x = torch.clamp(
+            (x - eta) * Q_b / (gamma + self.eps), self.eps, Q_b - self.eps
+        )
+        return scaled_x
+
+    def forward(self, input):
+        # Binarize weights
+        binarized_weights = self.binarize_weights()
+
+        # Normal linear transformation with binarized weights
+        output = torch.nn.functional.linear(input, binarized_weights, self.bias)
+
+        # Quantize activations (before non-linear functions like ReLU)
+        output = self.quantize_activations(output)
+
+        # For the sake of demonstration, we'll also include the scaling step.
+        # In practice, this would be done before a non-linear function in a forward pass.
+        output = self.scale_activations(output)
+
+        return output
+
+
+class BitLinear(nn.Linear):
+    def __init__(self, in_features, out_features, bias=True, num_groups=1):
+        super(BitLinear, self).__init__(in_features, out_features, bias)
+        self.num_groups = num_groups
+        self.eps = 1e-5
+
+    def ste_binarize(self, x):
+        # Apply the sign function for binarization
+        binarized_x = torch.sign(x)
+        # Use STE: during backward pass, we bypass the binarization
+        binarized_x = (binarized_x - x).detach() + x
+        return binarized_x
+
+    def binarize_weights_groupwise(self):
+        # Divide weights into groups
+        group_size = self.weight.shape[0] // self.num_groups
+        binarized_weights = torch.zeros_like(self.weight)
+
+        for g in range(self.num_groups):
+            start_idx = g * group_size
+            end_idx = (g + 1) * group_size
+            weight_group = self.weight[start_idx:end_idx]
+
+            # Binarize each group using STE
+            alpha_g = weight_group.mean()
+            binarized_weights[start_idx:end_idx] = self.ste_binarize(
+                weight_group - alpha_g
+            )
+
+        return binarized_weights
+
+    def quantize_activations_groupwise(self, x, b=8):
+        Q_b = 2 ** (b - 1)
+
+        # Divide activations into groups
+        group_size = x.shape[0] // self.num_groups
+        quantized_x = torch.zeros_like(x)
+
+        for g in range(self.num_groups):
+            start_idx = g * group_size
+            end_idx = (g + 1) * group_size
+            activation_group = x[start_idx:end_idx]
+
+            # Quantize each group
+            gamma_g = activation_group.abs().max()
+            quantized_x[start_idx:end_idx] = torch.clamp(
+                activation_group * Q_b / (gamma_g + self.eps),
+                -Q_b + self.eps,
+                Q_b - self.eps,
+            )
+
+        return quantized_x
+
+    def forward(self, input):
+        # Binarize weights (group-wise) using STE
+        binarized_weights = self.binarize_weights_groupwise()
+
+        # Normal linear transformation with binarized weights
+        output = torch.nn.functional.linear(input, binarized_weights, self.bias)
+
+        # Quantize activations group-wise
+        output = self.quantize_activations_groupwise(output)
+
+        return output
+
+
+class BitLinearOptimized(nn.Linear):
+    def __init__(self, in_features, out_features, bias=True, num_groups=1):
+        super(BitLinearOptimized, self).__init__(in_features, out_features, bias)
+        self.num_groups = num_groups
+        self.eps = 1e-5
+
+        # Initialize 1-bit quantized weights and store them as int8
+        self.register_buffer(
+            "quantized_weights", torch.sign(self.weight.data).to(torch.int8)
+        )
+        # Clear the original weights to save memory
+        del self.weight
+
+    @property
+    def weight(self):
+        # Return the dequantized weights when accessed
+        return self.dequantize_weights()
+
+    @weight.setter
+    def weight(self, value):
+        # Update the quantized_weights when the weight property is set
+        self.quantized_weights.data = torch.sign(value).to(torch.int8)
+
+    def dequantize_weights(self):
+        # Convert quantized_weights back to bfloat16 and compute alpha for the weights
+        bfloat16_weights = self.quantized_weights.to(torch.bfloat16)
+        alpha = bfloat16_weights.mean()
+        return bfloat16_weights * alpha
+
+    def ste_binarize(self, x):
+        # Apply the sign function for binarization
+        binarized_x = torch.sign(x)
+        # Use STE: during backward pass, we bypass the binarization
+        binarized_x = (binarized_x - x).detach() + x
+        return binarized_x
+
+    def binarize_weights_groupwise(self):
+        # Dequantize the weights before binarization
+        weights = self.dequantize_weights()
+
+        # Divide weights into groups
+        group_size = weights.shape[0] // self.num_groups
+        binarized_weights = torch.zeros_like(weights)
+
+        for g in range(self.num_groups):
+            start_idx = g * group_size
+            end_idx = (g + 1) * group_size
+            weight_group = weights[start_idx:end_idx]
+
+            # Binarize each group using STE
+            alpha_g = weight_group.mean()
+            binarized_weights[start_idx:end_idx] = self.ste_binarize(
+                weight_group - alpha_g
+            )
+
+        return binarized_weights
+
+    def quantize_activations_groupwise(self, x, b=8):
+        Q_b = 2 ** (b - 1)
+
+        # Divide activations into groups
+        group_size = x.shape[0] // self.num_groups
+        quantized_x = torch.zeros_like(x)
+
+        for g in range(self.num_groups):
+            start_idx = g * group_size
+            end_idx = (g + 1) * group_size
+            activation_group = x[start_idx:end_idx]
+
+            # Quantize each group
+            gamma_g = activation_group.abs().max()
+            quantized_x[start_idx:end_idx] = torch.clamp(
+                activation_group * Q_b / (gamma_g + self.eps),
+                -Q_b + self.eps,
+                Q_b - self.eps,
+            )
+
+        return quantized_x
+
+    def forward(self, input):
+        # Binarize weights (group-wise) using STE
+        binarized_weights = self.binarize_weights_groupwise()
+
+        # Normal linear transformation with binarized weights
+        output = torch.nn.functional.linear(input, binarized_weights, self.bias)
+
+        # Quantize activations group-wise
+        output = self.quantize_activations_groupwise(output)
+
+        return output


### PR DESCRIPTION
This adds linear variations and dictionary method for adding more variations.

Currently supported linear variations include :

- nn.Linear
- BitLinear
- BitLinearOptimized

The latter two are added from the following Apache 2.0 licensed repository:
https://github.com/Beomi/BitNet-Transformers/tree/main