### PR TITLE
Add scripts for testing out-of-distribution addition

### DIFF
--- a/data/ood_addition/generate_dataset.py
+++ b/data/ood_addition/generate_dataset.py
@@ -1,6 +1,7 @@
 import argparse
-from rich.progress import Progress, BarColumn, TextColumn, TimeRemainingColumn
+from rich.progress import Progress, BarColumn, TextColumn
 import time
+import random
 from datetime import datetime, timedelta
 import os
 
@@ -46,71 +47,79 @@ def detailed_addition(a, b):
     return outputs, int(final_result)
 
 
-from rich.progress import Progress, TextColumn, BarColumn, TimeRemainingColumn
-
-def test_all_additions(max_digits, output_file):
+def test_all_additions(max_digits, output_file, random_mode):
     start_time = time.time()
-    total_numbers = sum(10**n - 10**(n-1) for n in range(1, max_digits + 1))
-    total_tests = 9 * total_numbers
     correct = 0
     processed = 0
+
+    # Calculate the total tests and prepare the range of numbers
+    ranges = [(a, b) for a in range(1, 10) for num_digits in range(1, max_digits + 1)
+              for b in range(10**(num_digits-1), 10**num_digits)]
+    if random_mode:
+        ranges = random.sample(ranges, len(ranges))  # Randomly shuffle without repetition
+
+    total_tests = len(ranges)
 
     with open(output_file, 'w') as file, Progress(
         TextColumn("[bold blue]{task.fields[eta]}"),
         TextColumn("[bold blue]Completion: {task.fields[completion_time]}"),
         BarColumn(bar_width=None),
-        TextColumn("[progress.percentage]{task.percentage:>3.1f}% Complete"),  # Display percentage completion
+        TextColumn("[progress.percentage]{task.percentage:>3.1f}% Complete"),
         TextColumn("[bold green]{task.fields[mb]} MB"),
         TextColumn("[bold green]Final Size Estimate: {task.fields[final_mb_estimate]} MB")
     ) as progress:
         task = progress.add_task("Testing additions...", total=total_tests, eta="Calculating...",
                                  completion_time="Calculating...", mb="0.00 MB", final_mb_estimate="Calculating...")
 
-        for a in range(1, 10):
-            for num_digits in range(1, max_digits + 1):
-                for b in range(10**(num_digits-1), 10**num_digits):
-                    script_output, script_result = detailed_addition(a, b)
-                    correct_result = a + b
+        for a, b in ranges:
+            script_output, script_result = detailed_addition(a, b)
+            correct_result = a + b
 
-                    for line in script_output:
-                        file.write(line + '\n')
-                    file.flush()
-                    current_size = os.path.getsize(output_file) / (1024 * 1024)
-                    processed += 1
+            for line in script_output:
+                file.write(line + '\n')
+            file.flush()
+            current_size = os.path.getsize(output_file) / (1024 * 1024)
+            processed += 1
 
-                    elapsed_time = time.time() - start_time
-                    if processed > 0:
-                        avg_time_per_test = elapsed_time / processed
-                        eta_seconds = int(avg_time_per_test * (total_tests - processed))
-                        eta_minutes, eta_seconds = divmod(eta_seconds, 60)
-                        eta = f"{eta_minutes}m {eta_seconds}s"
+            # Update progress with time and file size estimates
+            elapsed_time = time.time() - start_time
+            update_progress(progress, task, processed, total_tests, elapsed_time, current_size)
 
-                        completion_time = datetime.now() + timedelta(seconds=eta_seconds)
-                        completion_time_str = completion_time.strftime('%Y-%m-%d %H:%M:%S')
-                        final_mb_estimate = (current_size / processed) * total_tests
-                    else:
-                        eta = "Calculating..."
-                        completion_time_str = "Calculating..."
-                        final_mb_estimate = "Calculating..."
-
-                    progress.update(task, advance=1, mb=f"{current_size:.2f}", eta=eta,
-                                    completion_time=completion_time_str, final_mb_estimate=f"{final_mb_estimate:.2f}")
-
-                    if script_result != correct_result:
-                        print(f"Error in addition a={a} and b={b}: Expected {correct_result}, got {script_result}")
-                    else:
-                        correct += 1
+            if script_result != correct_result:
+                print(f"Error in addition a={a} and b={b}: Expected {correct_result}, got {script_result}")
+            else:
+                correct += 1
 
         progress.remove_task(task)
     print(f"Number of correct results: {correct}/{total_tests}")
+
+def update_progress(progress, task, processed, total_tests, elapsed_time, current_size):
+    if processed > 0:
+        avg_time_per_test = elapsed_time / processed
+        eta_seconds = int(avg_time_per_test * (total_tests - processed))
+        eta_minutes, eta_seconds = divmod(eta_seconds, 60)
+        eta = f"{eta_minutes}m {eta_seconds}s"
+
+        completion_time = datetime.now() + timedelta(seconds=eta_seconds)
+        completion_time_str = completion_time.strftime('%Y-%m-%d %H:%M:%S')
+        final_mb_estimate = (current_size / processed) * total_tests
+    else:
+        eta = "Calculating..."
+        completion_time_str = "Calculating..."
+        final_mb_estimate = "Calculating..."
+
+    progress.update(task, advance=1, mb=f"{current_size:.2f}", eta=eta,
+                    completion_time=completion_time_str, final_mb_estimate=f"{final_mb_estimate:.2f}")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Test all possible additions for specified digit lengths.")
     parser.add_argument("--digits", type=int, default=2, help="Number of digits for the second number b")
     parser.add_argument("--output_file", type=str, default="input.txt", help="Output file name for results")
+    parser.add_argument("--random", action="store_true", help="Enable random selection of number combinations")
 
     args = parser.parse_args()
-    test_all_additions(args.digits, args.output_file)
+    test_all_additions(args.digits, args.output_file, args.random)
 
 if __name__ == "__main__":
     main()

--- a/data/ood_addition/generate_dataset.py
+++ b/data/ood_addition/generate_dataset.py
@@ -1,0 +1,113 @@
+import argparse
+
+def detailed_addition(a, b):
+    a = str(a)
+    b = str(b)
+    # Correctly pad 'b' to have one more digit than its current length
+    padded_b = '0' + b
+
+    result = []
+    carry = 0
+    max_length = len(padded_b)
+
+    outputs = []
+    outputs.append(f"s:a_{a}d0b_{'_'.join(padded_b)}c0e0")
+
+    for i in range(max_length):
+        digit_a = int(a) if i == 0 else '_'+a
+        active_a = f"a>{a}" if i == 0 else f"a{digit_a}"
+        digit_b = int(padded_b[max_length - 1 - i])
+        sum_digits = (int(a) if i == 0 else 0) + digit_b + carry
+
+        new_carry = sum_digits // 10
+        current_digit = sum_digits % 10
+        result.append(current_digit)
+
+        active_b_parts = list(padded_b)
+        active_b_parts[max_length - 1 - i] = '>' + active_b_parts[max_length - 1 - i]
+        active_b = '_'.join(active_b_parts)
+
+        previous_result = str(carry)
+        formatted_result = '^'.join(str(x) for x in reversed(result)) if i > 0 else str(current_digit)
+        formatted_result_e = '^' + formatted_result.replace('^', '_')
+        outputs.append(f"m:{active_a}d>{previous_result}b{active_b}c{new_carry}e{formatted_result_e}")
+
+        carry = new_carry
+
+    if carry > 0:
+        result.append(carry)
+    final_result = ''.join(str(x) for x in reversed(result))
+    outputs.append(f"r:a{digit_a}d{previous_result}b{padded_b}c0e{final_result}")
+
+    return outputs, int(final_result)
+
+def detailed_addition(a, b):
+    a = str(a)
+    b = str(b)
+    padded_b = '0' + b
+    result = []
+    carry = 0
+    max_length = len(padded_b)
+
+    outputs = []
+    outputs.append(f"s:a_{a}d0b_{'_'.join(padded_b)}c0e0")
+
+    for i in range(max_length):
+        digit_a = int(a) if i == 0 else '_'+a
+        active_a = f"a>{a}" if i == 0 else f"a{digit_a}"
+        digit_b = int(padded_b[max_length - 1 - i])
+        sum_digits = (int(a) if i == 0 else 0) + digit_b + carry
+
+        new_carry = sum_digits // 10
+        current_digit = sum_digits % 10
+        result.append(current_digit)
+
+        active_b_parts = list(padded_b)
+        active_b_parts[max_length - 1 - i] = '>' + active_b_parts[max_length - 1 - i]
+        active_b = '_'.join(active_b_parts)
+
+        previous_result = str(carry)
+        formatted_result = '^'.join(str(x) for x in reversed(result)) if i > 0 else str(current_digit)
+        formatted_result_e = '^' + formatted_result.replace('^', '_')
+        outputs.append(f"m:{active_a}d>{previous_result}b{active_b}c{new_carry}e{formatted_result_e}")
+
+        carry = new_carry
+
+    if carry > 0:
+        result.append(carry)
+    final_result = ''.join(str(x) for x in reversed(result))
+    outputs.append(f"r:a{digit_a}d{previous_result}b{padded_b}c0e{final_result}")
+
+    return outputs, int(final_result)
+
+
+def test_all_additions(max_digits, output_file):
+    correct = 0
+    total_tests = 0
+    with open(output_file, 'w') as file:
+        for a in range(1, 10):  # Single-digit 'a' from 1 to 9
+            for num_digits in range(1, max_digits + 1):  # Test for 1 to max_digits lengths of 'b'
+                for b in range(10**(num_digits-1), 10**num_digits):  # 'b' from the lowest to the highest with `num_digits`
+                    script_output, script_result = detailed_addition(a, b)
+                    correct_result = a + b
+                    total_tests += 1
+
+                    for line in script_output:
+                        file.write(line + '\n')
+                    if script_result == correct_result:
+                        correct += 1
+                    else:
+                        print(f"Error in addition a={a} and b={b}: Expected {correct_result}, got {script_result}")
+
+    print(f"Number of correct results: {correct}/{total_tests}")
+def main():
+    parser = argparse.ArgumentParser(description="Test all possible additions for specified digit lengths.")
+    parser.add_argument("--digits", type=int, default=2, help="Number of digits for the second number b")
+    parser.add_argument("--output_file", type=str, default="input.txt", help="Output file name for results")
+
+    args = parser.parse_args()
+    test_all_additions(args.digits, args.output_file)
+
+if __name__ == "__main__":
+    main()
+

--- a/data/ood_addition/generate_dataset.py
+++ b/data/ood_addition/generate_dataset.py
@@ -1,45 +1,10 @@
 import argparse
+from rich.progress import Progress, BarColumn, TextColumn, TimeRemainingColumn
+import time
+from datetime import datetime, timedelta
+import os
 
-def detailed_addition(a, b):
-    a = str(a)
-    b = str(b)
-    # Correctly pad 'b' to have one more digit than its current length
-    padded_b = '0' + b
 
-    result = []
-    carry = 0
-    max_length = len(padded_b)
-
-    outputs = []
-    outputs.append(f"s:a_{a}d0b_{'_'.join(padded_b)}c0e0")
-
-    for i in range(max_length):
-        digit_a = int(a) if i == 0 else '_'+a
-        active_a = f"a>{a}" if i == 0 else f"a{digit_a}"
-        digit_b = int(padded_b[max_length - 1 - i])
-        sum_digits = (int(a) if i == 0 else 0) + digit_b + carry
-
-        new_carry = sum_digits // 10
-        current_digit = sum_digits % 10
-        result.append(current_digit)
-
-        active_b_parts = list(padded_b)
-        active_b_parts[max_length - 1 - i] = '>' + active_b_parts[max_length - 1 - i]
-        active_b = '_'.join(active_b_parts)
-
-        previous_result = str(carry)
-        formatted_result = '^'.join(str(x) for x in reversed(result)) if i > 0 else str(current_digit)
-        formatted_result_e = '^' + formatted_result.replace('^', '_')
-        outputs.append(f"m:{active_a}d>{previous_result}b{active_b}c{new_carry}e{formatted_result_e}")
-
-        carry = new_carry
-
-    if carry > 0:
-        result.append(carry)
-    final_result = ''.join(str(x) for x in reversed(result))
-    outputs.append(f"r:a{digit_a}d{previous_result}b{padded_b}c0e{final_result}")
-
-    return outputs, int(final_result)
 
 def detailed_addition(a, b):
     a = str(a)
@@ -80,26 +45,65 @@ def detailed_addition(a, b):
 
     return outputs, int(final_result)
 
+
+from rich.progress import Progress, TextColumn, BarColumn, TimeRemainingColumn
 
 def test_all_additions(max_digits, output_file):
+    start_time = time.time()
+    total_numbers = sum(10**n - 10**(n-1) for n in range(1, max_digits + 1))
+    total_tests = 9 * total_numbers
     correct = 0
-    total_tests = 0
-    with open(output_file, 'w') as file:
-        for a in range(1, 10):  # Single-digit 'a' from 1 to 9
-            for num_digits in range(1, max_digits + 1):  # Test for 1 to max_digits lengths of 'b'
-                for b in range(10**(num_digits-1), 10**num_digits):  # 'b' from the lowest to the highest with `num_digits`
+    processed = 0
+
+    with open(output_file, 'w') as file, Progress(
+        TextColumn("[bold blue]{task.fields[eta]}"),
+        TextColumn("[bold blue]Completion: {task.fields[completion_time]}"),
+        BarColumn(bar_width=None),
+        TextColumn("[progress.percentage]{task.percentage:>3.1f}% Complete"),  # Display percentage completion
+        TextColumn("[bold green]{task.fields[mb]} MB"),
+        TextColumn("[bold green]Final Size Estimate: {task.fields[final_mb_estimate]} MB")
+    ) as progress:
+        task = progress.add_task("Testing additions...", total=total_tests, eta="Calculating...",
+                                 completion_time="Calculating...", mb="0.00 MB", final_mb_estimate="Calculating...")
+
+        for a in range(1, 10):
+            for num_digits in range(1, max_digits + 1):
+                for b in range(10**(num_digits-1), 10**num_digits):
                     script_output, script_result = detailed_addition(a, b)
                     correct_result = a + b
-                    total_tests += 1
 
                     for line in script_output:
                         file.write(line + '\n')
-                    if script_result == correct_result:
-                        correct += 1
-                    else:
-                        print(f"Error in addition a={a} and b={b}: Expected {correct_result}, got {script_result}")
+                    file.flush()
+                    current_size = os.path.getsize(output_file) / (1024 * 1024)
+                    processed += 1
 
+                    elapsed_time = time.time() - start_time
+                    if processed > 0:
+                        avg_time_per_test = elapsed_time / processed
+                        eta_seconds = int(avg_time_per_test * (total_tests - processed))
+                        eta_minutes, eta_seconds = divmod(eta_seconds, 60)
+                        eta = f"{eta_minutes}m {eta_seconds}s"
+
+                        completion_time = datetime.now() + timedelta(seconds=eta_seconds)
+                        completion_time_str = completion_time.strftime('%Y-%m-%d %H:%M:%S')
+                        final_mb_estimate = (current_size / processed) * total_tests
+                    else:
+                        eta = "Calculating..."
+                        completion_time_str = "Calculating..."
+                        final_mb_estimate = "Calculating..."
+
+                    progress.update(task, advance=1, mb=f"{current_size:.2f}", eta=eta,
+                                    completion_time=completion_time_str, final_mb_estimate=f"{final_mb_estimate:.2f}")
+
+                    if script_result != correct_result:
+                        print(f"Error in addition a={a} and b={b}: Expected {correct_result}, got {script_result}")
+                    else:
+                        correct += 1
+
+        progress.remove_task(task)
     print(f"Number of correct results: {correct}/{total_tests}")
+
 def main():
     parser = argparse.ArgumentParser(description="Test all possible additions for specified digit lengths.")
     parser.add_argument("--digits", type=int, default=2, help="Number of digits for the second number b")

--- a/data/ood_addition/prepare.py
+++ b/data/ood_addition/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/ood_addition/utils/meta_util.py
+++ b/data/ood_addition/utils/meta_util.py
@@ -1,0 +1,1 @@
+../template/utils/meta_util.py

--- a/data/ood_addition/utils/txt_to_phonemes.sh
+++ b/data/ood_addition/utils/txt_to_phonemes.sh
@@ -1,0 +1,1 @@
+../template/utils/txt_to_phonemes.sh

--- a/explorations/ood_addition_sweep.json
+++ b/explorations/ood_addition_sweep.json
@@ -1,0 +1,31 @@
+[
+    {
+      "max_iters": ["1000000"],
+      "patience": ["20"],
+      "n_layer": ["6"],
+      "n_kv_group": ["2"],
+      "n_head": ["6"],
+      "shared_mlp_size": ["1"],
+      "shared_mlp_sym": [true],
+      "shared_attn_size": ["2"],
+      "shared_attn_sym": [true],
+      "n_embd": ["384"],
+      "block_size":["88"],
+      "device": ["cuda"],
+      "dtype": ["float16"],
+      "dataset": ["ood_addition"],
+      "use_rotary_embeddings": [true],
+      "use_abs_pos_embeddings": [true],
+      "compile": [true],
+      "use_post_ln": [true, false],
+      "softmax_variant_attn": ["softmax", "polymax", "exppolymax", "saturatingconsmax"],
+      "consmax_initial_gamma": ["100.0"],
+      "consmax_initial_beta": ["2.5"],
+      "consmax_learnable_gamma": [false],
+      "consmax_learnable_beta": {
+          "conditions": [["softmax_variant_attn", "saturatingconsmax"]],
+          "options": [true, false]
+      }
+    }
+  ]
+

--- a/explorations/random_seed_tests.json
+++ b/explorations/random_seed_tests.json
@@ -19,9 +19,9 @@
           "step": 827
         }
       },
-      "softmax_variant_attn": ["softermax", "softmax", "constantmax"],
-      "constantmax_initial_beta": {
-          "conditions": [["softmax_variant_attn", "constantmax"]],
+      "softmax_variant_attn": ["softermax", "softmax", "consmax"],
+      "consmax_initial_beta": {
+          "conditions": [["softmax_variant_attn", "consmax"]],
           "options": ["2.5", "5.0", "10.0"]
       },
       "tensorboard_run_name": ["random_seed_tests"]

--- a/explorations/softmax_sweep.json
+++ b/explorations/softmax_sweep.json
@@ -12,7 +12,7 @@
       "use_rotary_embeddings": [false],
       "use_abs_pos_embeddings": [true],
       "compile": [false],
-      "softmax_variant_attn": ["strongermax", "softmax", "constantmax", "polymax", "exppolymax", "saturatingconsmax"],
+      "softmax_variant_attn": ["strongermax", "softmax", "consmax", "polymax", "exppolymax", "saturatingconsmax"],
       "polymax_divisor": {
           "conditions": [["softmax_variant_attn", "polymax"]],
           "options": ["10.0", "1000.0", "10000.0"]
@@ -41,11 +41,11 @@
           "conditions": [["softmax_variant_attn", "exppolymax"]],
           "options": ["2.0", "3.0"]
       },
-      "constantmax_initial_beta": {
+      "consmax_initial_beta": {
           "conditions": [["softmax_variant_attn", "saturatingconsmax"]],
           "options": ["1.5", "2.5", "3.5"]
       },
-      "constantmax_initial_gamma": {
+      "consmax_initial_gamma": {
           "conditions": [["softmax_variant_attn", "saturatingconsmax"]],
           "options": ["50.0", "100.0", "200.0"]
       },

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -23,14 +23,19 @@ class GPTConfig:
     shared_attn_sym: bool = False
 
     # Softmax Alternatives and Options
-    softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "constantmax"
-    softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "constantmax"
+    softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
+    softmax_variant_output: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"
 
-    ## Constantmax Options
-    constantmax_initial_beta: float = 0.0 # denominator to utilize for Constantmax
-    constantmax_initial_gamma: float = 1.0 # denominator to utilize for Constantmax
-    constantmax_use_euler_base: bool = True # use 'e' as base for Constantmax
-    constantmax_base: float = 2.0 # denominator to utilize for Constantmax
+    ## ConSmax Options
+    consmax_initial_beta: float = 2.0 # beta adjustment
+    consmax_initial_gamma: float = 100.0 # denominator adjustment
+    consmax_use_euler_base: bool = True # use 'e' as base for ConSmax, default
+    consmax_base: float = 2.0 # base to utilize for ConSmax
+
+    ## SaturatingConSmax special options (otherwise same as ConSmax)
+    consmax_saturation: float = 11.0 # for SaturatingConSmax saturation point
+    consmax_learnable_beta: bool = True
+    consmax_learnable_gamma: bool = True
 
     ## Softermax options
     softermax_use_xmax: bool = True # Softermax Option active is softermax selected - True: uses (x - x_max) normalization; False: removes normalization (potential overflow)
@@ -52,6 +57,7 @@ class GPTConfig:
     strongermax_use_xmax: bool = True # Softermax with option of 'stronger' (larger integer) bases
 
     ## ExpPolymax options
+    exppolymax_use_euler_base: bool = True
     exppolymax_base: float = 2.719
     exppolymax_y_intercept: float = 1.0
     exppolymax_power: float = 2.0

--- a/model.py
+++ b/model.py
@@ -19,7 +19,7 @@ from torch.nn import functional as F
 from gpt_conf import GPTConfig
 
 # Variations
-from variations.softmax_variations import softmax_dictionary, Softermax, Constantmax, Constantmax_quan, Strongermax, Polymax, SigSoftmax, ExpPolymax, SaturatingConSmax
+from variations.softmax_variations import softmax_dictionary, Softermax, ConSmax, ConSmaxQuan, Strongermax, Polymax, SigSoftmax, ExpPolymax, SaturatingConSmax
 from variations.norm_variations import norm_dictionary, LayerNorm, RMSNorm, pRMSNorm, kRMSNorm
 from variations.position_encoding_variations import RotaryEmbedding, ShortRope, SymmetricalOverlapAngularPositions, FIRE
 from variations.activation_variations import SquaredReLU, activation_dictionary

--- a/tests/test_all_softmax_variations_cpu.sh
+++ b/tests/test_all_softmax_variations_cpu.sh
@@ -6,7 +6,7 @@ cd ../
 dataset="shakespeare_char"
 python3 "data/${dataset}/prepare.py"
 
-softmax_variation=("softmax" "constantmax" "constantmax_quan" "polymax" "softermax" "sigsoftmax")
+softmax_variation=("softmax" "consmax" "consmax_quan" "polymax" "softermax" "sigsoftmax" "exppolymax" "saturatingconsmax" "strongermax")
 
 n_layer="2"
 n_head="2"

--- a/train.py
+++ b/train.py
@@ -121,58 +121,69 @@ def parse_args():
     # SOFTMAX VARIATIONS
     ## Selection of softmax variation for attention and output layers
     model_group.add_argument("--softmax_variant_attn", type=str,
-                             default="softmax", choices=["constantmax_quan",
-                                                         "constantmax",
+                             default="softmax", choices=[
+                                                         "saturatingconsmax",
+                                                         "consmax",
+                                                         "consmax_quan",
                                                          "polymax",
                                                          "strongermax",
                                                          "softermax",
                                                          "sigsoftmax",
                                                          "softmax",
-                                                         "saturatingconsmax",
                                                          "exppolymax",
                                                          ])
     model_group.add_argument("--softmax_variant_output", type=str,
-                             default="softmax", choices=["constantmax_quan",
-                                                         "constantmax",
+                             default="softmax", choices=[
+                                                         "saturatingconsmax",
+                                                         "consmax",
+                                                         "consmax_quan",
                                                          "polymax",
                                                          "strongermax",
                                                          "softermax",
                                                          "sigsoftmax",
                                                          "softmax",
-                                                         "saturatingconsmax",
                                                          "exppolymax",
                                                          ])
 
     ## Custom Softmax Variation Options
-    model_group.add_argument("--constantmax_initial_beta", type=float, default=2.5)
-    model_group.add_argument("--constantmax_initial_gamma", type=float, default=100.0)
+    ### ConSmax and SaturatingConSmax Options
+    model_group.add_argument("--consmax_initial_beta", type=float, default=2.5)
+    model_group.add_argument("--consmax_initial_gamma", type=float, default=100.0)
+    model_group.add_argument('--consmax_use_euler_base', default=True, action=argparse.BooleanOptionalAction)
+    model_group.add_argument("--consmax_base", type=float, default=2.0)
 
-    model_group.add_argument('--constantmax_use_euler_base', default=True, action=argparse.BooleanOptionalAction)
-    model_group.add_argument("--constantmax_base", type=float, default=2.0)
+    ### Special Options for SaturatingConSmax
+    model_group.add_argument("--consmax_saturation", type=float, default=11.0, help="point where we transition from consmax to linear saturatingconsmax, defaults to 11 to approximate e^x sat for fp16")
+    model_group.add_argument('--consmax_learnable_beta', default=True, action=argparse.BooleanOptionalAction)
+    model_group.add_argument('--consmax_learnable_gamma', default=True, action=argparse.BooleanOptionalAction)
 
+    ### Polymax Options
     model_group.add_argument("--polymax_x_intercept", type=float, default=-100.0)
     model_group.add_argument("--polymax_y_intercept", type=float, default=1.0)
     model_group.add_argument("--polymax_power", type=float, default=2.0)
     model_group.add_argument("--polymax_divisor", type=float, default=1000.0)
 
+    ### SigSoftmax Options
     model_group.add_argument('--sigsoftmax_use_euler_base', default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--sigsoftmax_base", type=float, default=2.0)
 
+    ### Strongermax Options - Testing Incremental Adjustments to Regular Softmax
     model_group.add_argument("--strongermax_strength", type=float, default=4.0)
     model_group.add_argument('--strongermax_sum_to_1', default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--strongermax_divisor", type=float, default=1.0)
     model_group.add_argument('--strongermax_use_xmax', default=True, action=argparse.BooleanOptionalAction)
 
+    ### ExpPolymax Options
+    model_group.add_argument('--exppolymax_use_euler_base', default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--exppolymax_base", type=float, default="4")
     model_group.add_argument("--exppolymax_y_intercept", type=float, default=1.0)
     model_group.add_argument("--exppolymax_power", type=float, default=2.0)
     model_group.add_argument("--exppolymax_divisor", type=float, default=1000.0)
 
-    # Softermax Specific Options
+    ### Softermax Specific Options
     model_group.add_argument('--softermax_use_xmax', default=True, action=argparse.BooleanOptionalAction)
 
     # Optimizer args
-    training_group.add_argument('--learning_rate', default=1e-3, type=float)
     training_group.add_argument('--max_iters', default=3500, type=int)
     training_group.add_argument('--weight_decay', default=1e-1, type=float)
     training_group.add_argument('--beta1', default=0.9, type=float)

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -206,7 +206,7 @@ class ExpPolymax(nn.Module):
         super().__init__()
 
         # Base selection
-        if config.expolymax_use_euler_base:
+        if config.exppolymax_use_euler_base:
             self.exppolymax_base = math.e
         else:
             self.exppolymax_base = config.exppolymax_base
@@ -224,7 +224,7 @@ class ExpPolymax(nn.Module):
         if config.exppolymax_power == 1.0:
             # Note: this only works with y=x an e^x, since we'd have to implement a multiplier or shift teh exponent otherwise.
             self.x_derivative_match_shift = 0
-        elif config.expolymax_use_euler_base:
+        elif config.exppolymax_use_euler_base:
             # ln(e) = 1
             self.x_derivative_match_shift = (1.0 / config.exppolymax_power)**(1/(config.exppolymax_power - 1))
         else:

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -18,26 +18,26 @@ class Softermax(nn.Module):
         return e_x / e_x.sum(dim=self.dim, keepdim=True)
 
 # Softmax variation with learnable constant parameters for xmax and denominator
-class Constantmax(nn.Module):
+class ConSmax(nn.Module):
     """ Constant learnable parameters for xmax and denominator """
     def __init__(self, config, dim=-1):
         super().__init__()
 
         # learnable 'xmax' - beta
-        self.beta = nn.Parameter(torch.Tensor([config.constantmax_initial_beta]))
+        self.beta = nn.Parameter(torch.Tensor([config.consmax_initial_beta]))
 
         # denominator - gamma
-        self.gamma = nn.Parameter(torch.Tensor([config.constantmax_initial_gamma]))
+        self.gamma = nn.Parameter(torch.Tensor([config.consmax_initial_gamma]))
 
         # Set the base of the exponent
-        if config.constantmax_use_euler_base:
-          self.constantmax_base = math.e
+        if config.consmax_use_euler_base:
+          self.consmax_base = math.e
         else:
-          self.constantmax_base = config.constantmax_base
+          self.consmax_base = config.consmax_base
 
     def forward(self, x):
         x = x - self.beta
-        e_x = torch.pow(self.constantmax_base, x)
+        e_x = torch.pow(self.consmax_base, x)
         return e_x / self.gamma
 
 # Constantmax Quantized
@@ -69,17 +69,17 @@ class const_quan(torch.autograd.Function):
 
 _const_quan=const_quan.apply
 
-class Constantmax_quan(nn.Module):
+class ConSmaxQuan(nn.Module):
     """ Base-e Softmax with option to remove max subtraction"""
     def __init__(self, config, dim=-1):
         super().__init__()
         self.dim = dim
 
         # demonimator - gamma
-        self.gamma = nn.Parameter(torch.Tensor([config.constantmax_initial_gamma]))
+        self.gamma = nn.Parameter(torch.Tensor([config.consmax_initial_gamma]))
 
         # learnable 'xmax' - beta
-        self.beta = nn.Parameter(torch.Tensor([config.constantmax_initial_beta]))
+        self.beta = nn.Parameter(torch.Tensor([config.consmax_initial_beta]))
 
         self.fake_beta = None
         self.fake_gamma = None
@@ -160,14 +160,25 @@ class SaturatingConSmax(nn.Module):
     def __init__(self, config):
         super().__init__()
 
-        if config.constantmax_use_euler_base:
-            self.constantmax_base = math.e
-        else:
-            self.constantmax_base = config.constantmax_base
 
-        self.divisor = config.constantmax_initial_gamma
-        self.beta = config.constantmax_initial_beta
-        self.x_sat = 11 + config.constantmax_initial_beta
+        if config.consmax_learnable_beta:
+            # learnable 'xmax' is beta
+            self.beta = nn.Parameter(torch.Tensor([config.consmax_initial_beta]))
+        else:
+            self.beta = config.consmax_initial_beta
+
+        if config.consmax_learnable_gamma:
+            # denominator is gamma
+            self.gamma = nn.Parameter(torch.Tensor([config.consmax_initial_gamma]))
+        else:
+            self.gamma = config.consmax_initial_gamma
+
+        if config.consmax_use_euler_base:
+            self.consmax_base = math.e
+        else:
+            self.consmax_base = config.consmax_base
+
+        self.x_sat = config.consmax_saturation + config.consmax_initial_beta
 
     def forward(self, x):
         # Overview:
@@ -177,24 +188,45 @@ class SaturatingConSmax(nn.Module):
         # Exponential section
         exponential_piece = torch.where(
             (x < (self.x_sat)),
-            torch.pow(self.constantmax_base, x - self.beta),
+            torch.pow(self.consmax_base, x - self.beta),
             torch.tensor(0.0, device=x.device))
 
         # flat section
         flat_piece = torch.where(x >= (self.x_sat), torch.tensor(self.x_sat, device=x.device), torch.tensor(0.0, device=x.device))
 
         # Combine sections
-        return (exponential_piece + flat_piece)/self.divisor
+        return (exponential_piece + flat_piece)/self.gamma
 
 # Merging of ConSmax body for gradient prop and Polymax head for numerical stability
 class ExpPolymax(nn.Module):
     def __init__(self, config):
         super().__init__()
 
-        self.exppolymax_base = config.exppolymax_base
+        # Base selection
+        if config.expolymax_use_euler_base:
+            self.exppolymax_base = math.e
+        else:
+            self.exppolymax_base = config.exppolymax_base
+
         self.y_intercept = config.exppolymax_y_intercept # where the graph crosses y-axis
         self.power = config.exppolymax_power
         self.divisor = config.exppolymax_divisor
+        # Assumes Euler Base:
+        # Shift of x to move poly portion forward to obtain continuous derivative at x=0
+        # derivative of poly at 0 should equal a^0
+        # d(x^n + y-int) = d(a^x|x=0) = ln(a) * a^0 = ln(a)
+        # n * x^(n-1) = ln(a)
+        # x = ln(a) * ( 1 / n ) ** (1/(n-1))
+        # Note: if n==1 (straight line) match is already attained, and calculation would nan, so test this case first
+        if config.exppolymax_power == 1.0:
+            # Note: this only works with y=x an e^x, since we'd have to implement a multiplier or shift teh exponent otherwise.
+            self.x_derivative_match_shift = 0
+        elif config.expolymax_use_euler_base:
+            # ln(e) = 1
+            self.x_derivative_match_shift = (1.0 / config.exppolymax_power)**(1/(config.exppolymax_power - 1))
+        else:
+            # ln(a) must be calculated
+            self.x_derivative_match_shift = torch.log2(config.exppolymax_base) * (1.0 / config.exppolymax_power)**(1/(config.exppolymax_power - 1))
 
     def forward(self, x):
         # Overview:
@@ -205,7 +237,7 @@ class ExpPolymax(nn.Module):
         exponential_piece = torch.where((x < 0), torch.pow(self.exppolymax_base, x), torch.tensor(0.0, device=x.device))
 
         # Polynomial section
-        poly_piece = torch.where(x > 0, x**self.power + self.y_intercept, torch.tensor(0.0, device=x.device))
+        poly_piece = torch.where(x >= 0, (x + self.x_derivative_match_shift)**self.power + self.y_intercept, torch.tensor(0.0, device=x.device))
 
         # Combine sections
         return (poly_piece + exponential_piece)/self.divisor
@@ -240,12 +272,12 @@ class SigSoftmax(nn.Module):
 
 # Note: we use the built in library for regular softmax
 softmax_dictionary = {
-    "constantmax": Constantmax,
-    "constantmax_quan": Constantmax_quan,
-    "exppolymax": ExpPolymax,
-    "polymax": Polymax,
+    "consmax": ConSmax,
+    "consmax_quan": ConSmaxQuan,
     "saturatingconsmax": SaturatingConSmax,
-    "sigsoftmax": SigSoftmax,
+    "polymax": Polymax,
+    "exppolymax": ExpPolymax,
     "softermax": Softermax,
     "strongermax": Strongermax,
+    "sigsoftmax": SigSoftmax,
 }


### PR DESCRIPTION
These are primarily scripts for testing out of distribution addition.

Transformers are bad at doing addition for lengths longer than what is in their training set.

This is an exploration into how we can get transformers to actually generalize with minimal context length.

Also added some fixes were added as well to help align softmax variations with the publication, these will help with testing to which combination of configurations does best for the length generalization.