### PR TITLE
merged with master and enabled plotting of strongermax/polymax

### DIFF
--- a/explorations/strongermax_sweep.json
+++ b/explorations/strongermax_sweep.json
@@ -18,7 +18,7 @@
     "use_post_ln": [true, false],
     "strongermax_use_xmax" : [true, false],
     "strongermax_sum_to_1": [true, false],
-    "statistics": ["all_stats"],
+    "statistic": ["all_stats"],
     "graph_type":["all"]
   }
 ]

--- a/explorations/strongermax_sweep.json
+++ b/explorations/strongermax_sweep.json
@@ -1,23 +1,26 @@
 [
-    {
-      "max_iters": ["8000"],
-      "n_layer": ["6"],
-      "n_kv_group": ["2"],
-      "n_head": ["6"],
-      "n_embd": ["384"],
-      "block_size":["256"],
-      "device": ["cuda"],
-      "dtype": ["float16"],
-      "dataset": ["shakespeare_char"],
-      "use_rotary_embeddings": [false],
-      "use_abs_pos_embeddings": [true],
-      "compile": [true],
-      "softmax_variant_attn": ["strongermax"],
-      "strongermax_strength": ["1.5", "2", "2.719", "3", "4", "5"],
-      "strongermax_divisor": ["1.0", "10.0", "100.0", "1000.0"],
-      "use_post_ln": [true, false],
-      "strongermax_use_xmax" : [true, false],
-      "strongermax_sum_to_1": [true, false]
-    }
-  ]
+  {
+    "max_iters": ["8000"],
+    "n_layer": ["6"],
+    "n_kv_group": ["6"],
+    "n_head": ["6"],
+    "n_embd": ["384"],
+    "block_size":["256"],
+    "device": ["cuda"],
+    "dtype": ["float16"],
+    "dataset": ["shakespeare_char"],
+    "use_rotary_embeddings": [false],
+    "use_abs_pos_embeddings": [true],
+    "compile": [true],
+    "softmax_variant_attn": ["strongermax"],
+    "strongermax_strength": ["1.5", "2", "2.719", "3", "4", "5"],
+    "strongermax_divisor": ["1.0", "10.0", "100.0", "1000.0"],
+    "use_post_ln": [true, false],
+    "strongermax_use_xmax" : [true, false],
+    "strongermax_sum_to_1": [true, false],
+    "statistics": ["all_stats"],
+    "graph_type":["all"]
+  }
+]
+
 

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -75,3 +75,4 @@ yarl==1.9.2
 rich==13.5.3
 plotly==5.22.0
 seaborn==0.13.2
+kaleido==0.2.1

--- a/train.py
+++ b/train.py
@@ -631,6 +631,7 @@ class Trainer:
                     # Name the x and y axis
                     ax.set_xticks(np.arange(len(x_labels)), labels=x_labels)
                     ax.set_yticks(np.arange(len(y_labels)), labels=y_labels)
+                    plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
                     ax.set_xlabel("Number of Iterations", fontweight="bold")
                     
                     # Create a colorbar

--- a/train.py
+++ b/train.py
@@ -241,7 +241,7 @@ def parse_args():
     logging_group.add_argument('--statistic', choices=[
     'input_mean', 'input_median', 'input_stdev', 'input_max', 'input_min',
     'output_mean', 'output_median', 'output_stdev', 'output_max', 'output_min', 'all_stats', 'input_all','output_all'
-], default='input_mean', help='Select one or more statistics to display, e.g., --statistic input_mean output_max')
+], default='input_mean', help='Select one or all statistics to display, e.g., --statistic input_min, or --statistic all_stats')
 
 
     args = parser.parse_args()


### PR DESCRIPTION
Extended plotting of input/output statistics to strongermax and polymax, used similarly to consmax by specifying the stats to be visualized. Command line would look like: 
python3 train.py --out_dir=out --device=cpu --eval_interval=2 --log_interval=1 --block_size=2 --batch_size=5 --n_layer=3 --n_head=4 --n_embd=16 --lr_decay_iters=2 --dtype="float32" --max_iter=20 --softmax_variant_attn="polymax" --statistic=output_mean

