### PR TITLE
Fixed typo in consmax_sweep config

### DIFF
--- a/explorations/consmax_sweep.json
+++ b/explorations/consmax_sweep.json
@@ -13,8 +13,8 @@
       "use_abs_pos_embeddings": [true],
       "compile": [true],
       "softmax_variant_attn": ["consmax"],
-      "consmax_intial_beta":["1.0","1.5","2","2.5","3","3.5","4","4.5","5"],
-      "consmax_intial_gamma":["20.0","40.0","60.0","80.0","100.0"],
+      "consmax_initial_beta":["1.0","1.5","2","2.5","3","3.5","4","4.5","5"],
+      "consmax_initial_gamma":["20.0","40.0","60.0","80.0","100.0"],
       "consmax_use_euler_base": [true,false],
       "consmax_base": ["1.5", "2", "2.719", "3", "4", "5"],
       "use_post_ln": [true, false]


### PR DESCRIPTION
Fixed a minor typo in the consmax_sweep.json config file that was causing experiments to fail. 