### PR TITLE
Added boxplots

### DIFF
--- a/explorations/strongermax_sweep.json
+++ b/explorations/strongermax_sweep.json
@@ -1,6 +1,6 @@
 [
   {
-    "max_iters": ["8000"],
+    "max_iters": ["6000"],
     "n_layer": ["6"],
     "n_kv_group": ["6"],
     "n_head": ["6"],
@@ -19,6 +19,9 @@
     "strongermax_use_xmax" : [true, false],
     "strongermax_sum_to_1": [true, false],
     "statistic": ["all_stats"],
-    "graph_type":["all"]
+    "graph_type":["all"],
+    "box_plot_interval": ["1000"],
+    "box_plot_statistic": ["all"],
+    "patience": ["1000"]
   }
 ]

--- a/train.py
+++ b/train.py
@@ -249,15 +249,18 @@ def parse_args():
     logging_group.add_argument('--wandb_log', default=False, action=argparse.BooleanOptionalAction)
     logging_group.add_argument('--wandb_project', type=str, default='out-test')
     logging_group.add_argument('--wandb_run_name', type=str, default='logs-test')
+
+    # Visualization args
     logging_group.add_argument('--statistic', choices=[
     'input_mean', 'input_median', 'input_stdev', 'input_max', 'input_min',
     'output_mean', 'output_median', 'output_stdev', 'output_max', 'output_min', 'all_stats', 'input_all','output_all'
-], default='input_mean', help='Select one or all statistics to display, e.g., --statistic input_min, or --statistic all_stats')
+     ], default='input_mean', help='Select one or all statistics to display, e.g., --statistic input_min, or --statistic all_stats')
     logging_group.add_argument('--graph_type', choices=[
-    "heatmap", "plot", "all"
-], default='no_graph', help='Select one of the graph types to display, e.g., --graph_type heatmap, or --graph_type plot')
-    
-
+    "heatmap", "plot", "boxplot", "all"
+     ], default='no_graph', help='Select one of the graph types to display, e.g., --graph_type heatmap, or --graph_type plot')
+    logging_group.add_argument('--box_plot_interval', default=1000, type=int, help='Instead of using mean/median/stdev statistics, create box plot of all input/output values at certain intervals of iteration')
+    logging_group.add_argument('--box_plot_statistic', choices=['input', 'output', 'all'],
+     default='', help='Select input or output statistic to display in boxplot')
 
     args = parser.parse_args()
     return args, model_group, training_group, logging_group
@@ -555,8 +558,31 @@ class Trainer:
                 "train/loss": loss_training,
                 "mfu": running_mfu*100,
             })
+
+    def create_box_plot(self, plot_data, y_labels, timestamp, data_type, stat_type):
+        directory_path = os.path.join(self.args.out_dir, 'images')
+        os.makedirs(directory_path, exist_ok=True)
+
+        # create a boxplot
+        fig = plt.figure(figsize =(10, 7))
+        ax = fig.add_subplot(111)
+
+        # Creating axes instance
+        ax.boxplot(plot_data, sym = '', patch_artist = True, vert = 0)
+
+        # y-axis labels
+        ax.set_yticklabels(y_labels)
+
+        # Removing top axes and right axes
+        # ticks
+        ax.get_xaxis().tick_bottom()
+        ax.get_yaxis().tick_left()
+            
+        ax.set_title(f"Boxplot of {data_type} {stat_type}")
+        plt.savefig(f'{directory_path}/{data_type}_{stat_type}_boxplot_{timestamp}.png')
+        plt.close()
     
-    def plot_statistics(self):
+    def plot_statistics(self, graph_y_labels):
             statistics_to_plot = []
             timestamp = time.strftime('%Y-%m-%d_%H-%M-%S', time.localtime())
             directory_path = os.path.join(self.args.out_dir, 'images')
@@ -614,13 +640,6 @@ class Trainer:
                     # create a heatmap
                     plt.figure(figsize=(10, 6))
 
-                    # create ylabels
-                    y_labels = []
-                    # Reduce first two dimensions to 1D
-                    # combing layer_idx and head_idx
-                    for layer_idx, stats_per_layer in enumerate(self.stats[stat_prefix + stat_type]):
-                        for head_idx, data in enumerate(stats_per_layer):
-                            y_labels.append(f"Layer {layer_idx} Head {head_idx}")
                     #data is the value of #iter
                     # create xlabels
                     num_iters = len(data)
@@ -641,7 +660,7 @@ class Trainer:
                     im = ax.imshow(plot_data)
                     # Name the x and y axis
                     ax.set_xticks(np.arange(len(x_labels)), labels=x_labels)
-                    ax.set_yticks(np.arange(len(y_labels)), labels=y_labels)
+                    ax.set_yticks(np.arange(len(graph_y_labels)), labels=graph_y_labels)
                     plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
                     ax.set_xlabel("Number of Iterations", fontweight="bold")
                     
@@ -653,8 +672,14 @@ class Trainer:
                     plt.savefig(f'{directory_path}/{data_type}_{stat_type}_heatmap_{timestamp}.png')
                     plt.close()
 
+                if self.args.graph_type == 'boxplot' or self.args.graph_type == 'all':
+                    # create plot_data
+                    plot_data = []
+                    for layer_idx, stats_per_layer in enumerate(self.stats[stat_prefix + stat_type]):
+                        for head_idx, data in enumerate(stats_per_layer):
+                            plot_data.append(np.array(data))
 
-
+                    self.create_box_plot(plot_data, graph_y_labels, timestamp, data_type, stat_type)
 
     def train(self):
         self.X, self.Y = self.get_batch('train')
@@ -662,6 +687,10 @@ class Trainer:
         local_iter_num = 0
         running_mfu = -1.0
         num_steps_with_worse_loss = 0
+        graph_y_labels = []
+        for layer in range(self.args.n_layer):
+            for head in range(self.args.n_head):
+                graph_y_labels.append(f"Layer {layer} Head {head}")
 
         while True:
             lr = self.get_lr(self.iter_num) if self.args.decay_lr else self.args.learning_rate
@@ -693,6 +722,7 @@ class Trainer:
                         torch.save(checkpoint, os.path.join(self.args.out_dir, 'ckpt.pt'))
                 if self.args.patience is not None and num_steps_with_worse_loss >= self.args.patience:
                     print(f"Early Stopping: loss has not decreased in {self.args.patience + 1} steps")
+                    self.plot_statistics(graph_y_labels)
                     break
                 if losses['val'] > self.best_val_loss:
                     num_steps_with_worse_loss += 1
@@ -766,6 +796,9 @@ class Trainer:
                 o_max_values = []
                 o_min_values = []
 
+                box_plot_input_data = []
+                box_plot_output_data = []
+                        
                 for layer in range (self.args.n_layer):
                     # Inputs
                     inputs_location = f"transformer.h[{layer}].attn.softmax_layer_attn.inputs"
@@ -777,13 +810,9 @@ class Trainer:
                     i_first_batch = softmax_input[0]
                     i_first_batch[i_first_batch == float('-inf')] = float('NaN')
 
-
                     for i, i_head in enumerate(i_first_batch):
-                        
-
                         ## Flatten across heads, height, and width
                         flattened = i_head.view(-1)
-
                         
                         ## Calculate statistics
                         i_means.append(torch.nanmean(flattened).item())
@@ -793,6 +822,9 @@ class Trainer:
                         mask = ~torch.isnan(i_head)
                         i_stdevs.append(torch.std(i_head[mask]).item())
                         i_sum_vals.append(torch.sum(i_head[mask]).item())
+
+                        if self.iter_num % self.args.box_plot_interval == 0 and (self.args.box_plot_statistic == "all" or self.args.box_plot_statistic == "input"):
+                            box_plot_input_data.append(i_head[mask].detach().numpy())
 
                         # Max, temporarily replacing NaNs with -inf for calculation
                         i_max_values.append(torch.max(torch.where(torch.isnan(i_head), torch.tensor(float('-inf')), i_head)).item())
@@ -829,6 +861,10 @@ class Trainer:
                         mask = ~torch.isnan(o_head)
                         o_stdevs.append(torch.std(o_head[mask]).item())
                         o_sum_vals.append(torch.sum(o_head[mask]).item())
+
+                        if self.iter_num % self.args.box_plot_interval == 0 and (self.args.box_plot_statistic == "all" or self.args.box_plot_statistic == "output"):
+                            box_plot_output_data.append(o_head[mask].detach().numpy())
+
                         # Max, temporarily replacing NaNs with -inf for calculation
                         o_max_values.append(torch.max(torch.where(torch.isnan(o_head), torch.tensor(float('-inf')), o_head)).item())
                         o_min_values.append(torch.min(torch.where(torch.isnan(o_head), torch.tensor(float('inf')), o_head)).item())
@@ -855,6 +891,16 @@ class Trainer:
 
                         self.log_gamma_beta(gamma, beta, self.iter_num, layer)
 
+                if self.args.box_plot_statistic and (self.iter_num % self.args.box_plot_interval == 0) and self.iter_num != 0:
+                    timestamp = time.strftime('%Y-%m-%d_%H-%M-%S', time.localtime())
+                    if self.args.box_plot_statistic == "all":
+                        self.create_box_plot(box_plot_input_data, graph_y_labels, timestamp, "input", self.iter_num)
+                        self.create_box_plot(box_plot_output_data, graph_y_labels, timestamp, "output", self.iter_num)
+                    elif self.args.box_plot_statistic == "input":
+                        self.create_box_plot(box_plot_input_data, graph_y_labels, timestamp, self.args.box_plot_statistic, self.iter_num)
+                    else:
+                        self.create_box_plot(box_plot_output_data, graph_y_labels, timestamp, self.args.box_plot_statistic, self.iter_num)
+                    
 
                 self.write_to_csv(self.iter_num,
                                   *i_sum_vals,
@@ -904,7 +950,7 @@ class Trainer:
             local_iter_num += 1
 
             if self.iter_num > self.args.max_iters:
-                self.plot_statistics()
+                self.plot_statistics(graph_y_labels)
                 if self.args.only_save_checkpoint_at_end:
                     checkpoint = {
                         'model': self.raw_model.state_dict(),

--- a/train.py
+++ b/train.py
@@ -606,7 +606,7 @@ class Trainer:
                 # draw the plot
                 if self.args.graph_type == 'plot' or self.args.graph_type == 'all':
                     fig = go.Figure()
-                    plt.figure(figsize=(10, 6))
+                    plt.figure(figsize=(18, 8))
                     for layer_idx, stats_per_layer in enumerate(self.stats[stat_prefix + stat_type]):
                         for head_idx, data in enumerate(stats_per_layer):
                             fig.add_trace(go.Scatter(
@@ -622,7 +622,9 @@ class Trainer:
                         title=f'Change in {stat_type.title()} Values for {data_type.capitalize()} During Training',
                         xaxis_title='Training Iteration',
                         yaxis_title=f'{stat_type.title()} of {data_type.capitalize()}',
-                        legend_title='Head/Layer'
+                        legend_title='Head/Layer',
+                        height=890,
+                        width=1200
                     )
                     fig.write_html(f'{directory_path}/{data_type}_{stat_type}_changes_plotly_{timestamp}.html')
                     fig.write_image(f'{directory_path}/{data_type}_{stat_type}_changes_plotly_{timestamp}.png')
@@ -631,15 +633,13 @@ class Trainer:
                     plt.title(f'Change in {stat_type.title()} Values for {data_type.capitalize()} During Training')
                     plt.xlabel('Training Iteration')
                     plt.ylabel(f'{stat_type.title()} of {data_type.capitalize()}')
-                    plt.legend(title='Head/Layer')
+                    plt.legend(loc='center left', bbox_to_anchor=(1, 0.5), title='Head/Layer')
+                    # plt.legend(title='Head/Layer')
                     plt.grid(True)
                     plt.savefig(f'{directory_path}/{data_type}_{stat_type}_changes_plot_{timestamp}.png')
                     plt.close()
 
                 if self.args.graph_type == 'heatmap' or self.args.graph_type == 'all':
-                    # create a heatmap
-                    plt.figure(figsize=(10, 6))
-
                     #data is the value of #iter
                     # create xlabels
                     num_iters = len(data)
@@ -656,7 +656,7 @@ class Trainer:
                     plot_data = np.array(plot_data)
                     
                     ######
-                    fig, ax = plt.subplots()
+                    fig, ax = plt.subplots(figsize=(8,10))
                     im = ax.imshow(plot_data)
                     # Name the x and y axis
                     ax.set_xticks(np.arange(len(x_labels)), labels=x_labels)


### PR DESCRIPTION
For statistics, added a boxplot graph option.

Also, added the argument box_plot_interval which allows for the creation of box plots of all input/output values at certain specified intervals of iteration. For example, with box_plot_interval=1000, a box plot will be created using the input/output values of one iteration every 1000 iterations. This will allow us to compare the input/output statistics throughout training.  

Also, made some fixes to the other plots so that legends and text aren't cut off.



Some example box plots:
![image](https://github.com/ReaLLMASIC/nanoGPT/assets/91397835/0e2c64ee-a34c-420b-8a16-986676f7b0f7)
![image](https://github.com/ReaLLMASIC/nanoGPT/assets/91397835/7f387c4a-a5c3-48c4-bc9b-398bcd3cf372)