### PR TITLE
Add settings log, graphs, and model augmentation to sample.py

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -79,6 +79,7 @@ class GPTConfig:
     use_fire_embeddings: bool = False
     shared_fire_embeddings: bool = False
     use_rotary_embeddings: bool = False
+    sym_rot_num_angles: int = 512
     rope_variant: str = "rope" # options: "shortrope", "rope"
     shortrope_length: int = 8 # number of embeddings to use in shortrope
 

--- a/model.py
+++ b/model.py
@@ -121,9 +121,11 @@ class CausalSelfAttention(nn.Module):
         self.rotary_emb_k = None
         if config.use_rotary_embeddings:
             # TODO update variant name after completing rope and shortrope updates
+            # TODO Add shortrope to symmetrical rope
             if config.rope_variant == "rope":
-                self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd)
-                self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=self.kv_dim, num_angles=256)
+                self.sym_rot_num_angles = config.sym_rot_num_angles
+                self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd, num_angles=self.sym_rot_num_angles)
+                self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=self.kv_dim, num_angles=self.sym_rot_num_angles)
             # TODO update rope and shortrope to accomodate new GQA additions
             # if config.rope_variant == "rope":
             #     self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd)
@@ -220,7 +222,7 @@ class CausalSelfAttention(nn.Module):
                 att = att.masked_fill(window_mask == 0, float('-inf'))
             else:
                 # regular lower triangle attention
-                att = att.masked_fill(self.bias[:,:,:T,:T] == 0, float('-inf'))
+                att = att.masked_fill(self.bias[:,:,:T,:T].to(x.device) == 0, float('-inf'))
 
             # fire position embeddings
             if self.use_fire_embeddings is not None:
@@ -386,6 +388,15 @@ class GPT(nn.Module):
             n_params -= self.transformer.wpe.weight.numel()
         return n_params
 
+    def update_block_size(self, new_block_size):
+        # Function to increase block size dynamically
+        if new_block_size > self.config.block_size:
+            self.config.block_size = new_block_size
+            self.transformer.wpe = nn.Embedding(new_block_size, self.config.n_embd)
+            for block in self.transformer.h:
+                if hasattr(block.attn, 'bias'):
+                    block.attn.bias = torch.tril(torch.ones(new_block_size, new_block_size)).view(1, 1, new_block_size, new_block_size)
+
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
@@ -394,16 +405,25 @@ class GPT(nn.Module):
         elif isinstance(module, nn.Embedding):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
 
+    def update_num_angles(self, num_angles):
+        """Update the number of angles for rotary embeddings in all attention layers."""
+        device = next(self.parameters()).device
+        for block in self.transformer.h:
+            if hasattr(block.attn, 'rotary_emb_q') and hasattr(block.attn, 'rotary_emb_k'):
+                block.attn.rotary_emb_q.update_num_angles(num_angles, device)
+                block.attn.rotary_emb_k.update_num_angles(num_angles, device)
+
+
     def forward(self, idx, targets=None):
         device = idx.device
         b, t = idx.size()
-        assert t <= self.config.block_size, f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
-        pos = torch.arange(0, t, dtype=torch.long, device=device) # shape (t)
+        # assert t <= self.config.block_size, f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
 
         # forward the GPT model itself
         tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
         x = None
         if self.config.use_abs_pos_embeddings:
+          pos = torch.arange(0, t, dtype=torch.long, device=device) # shape (t)
           pos_emb = self.transformer.wpe(pos) # position embeddings of shape (t, n_embd)
           x = self.transformer.drop(tok_emb + pos_emb)
         else:

--- a/sample.py
+++ b/sample.py
@@ -51,6 +51,19 @@ def save_heatmap(probs, idx, decode, step, out_dir, last_k_tokens):
     plt.savefig(out_path)
     plt.close()
 
+def interactive_generation(model, start_ids, device, max_new_tokens, temperature, top_k, stop_string, decode, encode):
+    x = torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...]
+    while True:
+        x, generated_text = model.generate_with_stop(x, max_new_tokens, stop_string, decode, temperature, top_k)
+        print("[bold green]" + generated_text)
+
+        user_input = input("User input (or 'exit' to quit): ")
+        if user_input.lower() == 'exit':
+            break
+
+        # Append the user input directly after the stop string
+        x = torch.cat((x, torch.tensor(encode(user_input), dtype=torch.long, device=device)[None, ...]), dim=1)
+
 args = parseargs()
 # -----------------------------------------------------------------------------
 

--- a/sample.py
+++ b/sample.py
@@ -1,41 +1,45 @@
-from torch.nn import functional as F
+import argparse
+import json
 import os
 import pickle
 from contextlib import nullcontext
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
 import torch
 import tiktoken
 from rich import print
-from model import GPTConfig, GPT
-import argparse
-import matplotlib.pyplot as plt
-import seaborn as sns
-from datetime import datetime
-import numpy as np
-import json
+from torch.nn import functional as F
 
-def parseargs():
-    parser = argparse.ArgumentParser(description='')
-    parser.add_argument("--device", type=str, help="device to run inference, e.g. 'cpu' or 'cuda' or 'cuda:0', 'cuda:1', etc...")
-    parser.add_argument("--out_dir", type=str, help="directory to load checkpoint from")
-    parser.add_argument("--init_from", type=str, default="resume", help="Either 'resume' (from an out_dir) or a gpt2 variant (e.g. 'gpt2-xl')")
-    parser.add_argument("--start", type=str, default="\n", help="\\n or '<|endoftext|>' or etc. Can also specify a file, use as: 'FILE:prompt.txt'")
-    parser.add_argument("--num_samples", type=int, default=3, help="number of inference streams to draw")
-    parser.add_argument("--max_new_tokens", type=int, default=500, help="number of tokens generated in each sample")
-    parser.add_argument("--temperature", type=float, default=0.8, help="1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions")
-    parser.add_argument("--top_k", type=int, default=200, help="retain only the top_k most likely tokens, clamp others to have 0 probability")
-    parser.add_argument("--seed", type=int, default=1337, help="seed for psuedorandom number generator")
-    parser.add_argument("--dtype", type=str, default="bfloat16", choices=["bfloat16", "float16", "float32"], help="torch data type for inference, e.g. 'int8'")
-    parser.add_argument('--compile', default=False, action=argparse.BooleanOptionalAction)
-    parser.add_argument('--sample_file', type=str, default=None, help="output file for inference")
-    parser.add_argument('--interactive', default=False, action=argparse.BooleanOptionalAction)
-    parser.add_argument('--stop_string', type=str, default='~W', help="fixed string to stop generation and allow user input")
-    parser.add_argument('--show_heatmaps', default=False, action=argparse.BooleanOptionalAction, help="show heatmaps of top-k choices for each token")
-    parser.add_argument('--last_k_tokens', type=int, default=10, help="number of last tokens to display in heatmaps")
-    parser.add_argument('--chart_type', type=str, default='heatmap', choices=['heatmap', 'barchart'], help="type of chart to display: 'heatmap' or 'barchart'")
-    parser.add_argument('--block_size', type=int, default=None, help="block size for context length, default is model's block size")
-    parser.add_argument('--sym_rot_num_angles', type=int, default=None, help="new symmetrical rotary embedding number of angles")
+from model import GPT, GPTConfig
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Inference from trained models")
+    parser.add_argument("--device", type=str, required=True, help="Device to run inference (e.g., 'cpu', 'cuda', 'cuda:0', 'cuda:1')")
+    parser.add_argument("--out_dir", type=str, required=True, help="Directory to load checkpoint from")
+    parser.add_argument("--init_from", type=str, default="resume", help="Either 'resume' (from an out_dir) or a GPT-2 variant (e.g., 'gpt2-xl')")
+    parser.add_argument("--start", type=str, default="\n", help="Start text for generation. Can specify a file using 'FILE:prompt.txt'")
+    parser.add_argument("--num_samples", type=int, default=3, help="Number of inference streams to draw")
+    parser.add_argument("--max_new_tokens", type=int, default=500, help="Number of tokens to generate in each sample")
+    parser.add_argument("--temperature", type=float, default=0.8, help="Temperature for predictions (1.0 = no change, < 1.0 = less random, > 1.0 = more random)")
+    parser.add_argument("--top_k", type=int, default=200, help="Retain only the top_k most likely tokens")
+    parser.add_argument("--seed", type=int, default=1337, help="Seed for pseudorandom number generator")
+    parser.add_argument("--dtype", type=str, default="bfloat16", choices=["bfloat16", "float16", "float32"], help="Torch data type for inference")
+    parser.add_argument('--compile', action=argparse.BooleanOptionalAction, help="Compile the model (requires PyTorch 2.0)")
+    parser.add_argument('--sample_file', type=str, default=None, help="Output file for inference")
+    parser.add_argument('--interactive', action=argparse.BooleanOptionalAction, help="Enable interactive generation")
+    parser.add_argument('--stop_string', type=str, default='~W', help="String to stop generation and allow user input")
+    parser.add_argument('--show_heatmaps', action=argparse.BooleanOptionalAction, help="Show heatmaps of top-k choices for each token")
+    parser.add_argument('--last_k_tokens', type=int, default=10, help="Number of last tokens to display in heatmaps")
+    parser.add_argument('--chart_type', type=str, default='heatmap', choices=['heatmap', 'barchart'], help="Type of chart to display: 'heatmap' or 'barchart'")
+    parser.add_argument('--block_size', type=int, default=None, help="Block size for context length, default is model's block size")
+    parser.add_argument('--sym_rot_num_angles', type=int, default=None, help="Number of angles for symmetrical rotary embedding")
 
     return parser.parse_args()
+
 
 def save_chart(probs, idx, decode, step, out_dir, last_k_tokens, chart_type, selected_token):
     top_k_probs, top_k_indices = torch.topk(probs, k=probs.size(-1))
@@ -45,17 +49,16 @@ def save_chart(probs, idx, decode, step, out_dir, last_k_tokens, chart_type, sel
 
     if chart_type == 'heatmap':
         sns.heatmap(top_k_probs.cpu().numpy().reshape(1, -1), annot=np.array(top_k_tokens).reshape(1, -1), fmt='', cmap='viridis')
-        plt.title(f"Step {step}: Top-k Token Probabilities")
     elif chart_type == 'barchart':
         colors = sns.color_palette('viridis', len(top_k_tokens))
         bars = plt.bar(top_k_tokens, top_k_probs.cpu().numpy().flatten(), color=colors)
-        plt.title(f"Step {step}: Top-k Token Probabilities")
         plt.xticks(rotation=90)
         for bar, token in zip(bars, top_k_tokens):
             if token == selected_token:
                 bar.set_edgecolor('red')
                 bar.set_linewidth(2)
 
+    plt.title(f"Step {step}: Top-k Token Probabilities")
     last_tokens = decode(idx[0, -last_k_tokens:].tolist())
     plt.xlabel(f"Last {last_k_tokens} Tokens: {last_tokens}")
 
@@ -64,6 +67,7 @@ def save_chart(probs, idx, decode, step, out_dir, last_k_tokens, chart_type, sel
     os.makedirs(out_dir, exist_ok=True)
     plt.savefig(out_path)
     plt.close()
+
 
 def interactive_generation(model, start_ids, device, max_new_tokens, temperature, top_k, stop_string, decode, encode):
     x = torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...]
@@ -78,122 +82,116 @@ def interactive_generation(model, start_ids, device, max_new_tokens, temperature
         # Append the user input directly after the stop string
         x = torch.cat((x, torch.tensor(encode(user_input), dtype=torch.long, device=device)[None, ...]), dim=1)
 
+
 def save_args(args, out_dir):
     with open(os.path.join(out_dir, 'args.json'), 'w') as f:
         json.dump(vars(args), f, indent=4)
 
-args = parseargs()
-# -----------------------------------------------------------------------------
 
-torch.manual_seed(args.seed)
-torch.cuda.manual_seed(args.seed)
-torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
-torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in args.device else 'cpu' # for later use in torch.autocast
-ptdtype = {'bfloat16': torch.bfloat16, 'float16': torch.float16, 'float32': torch.float32}[args.dtype]
-ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+def main():
+    args = parse_args()
 
-# Create timestamped directory within out_dir
-timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-out_dir = os.path.join(args.out_dir, timestamp)
-os.makedirs(out_dir, exist_ok=True)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed(args.seed)
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    device_type = 'cuda' if 'cuda' in args.device else 'cpu'
+    ptdtype = {'bfloat16': torch.bfloat16, 'float16': torch.float16, 'float32': torch.float32}[args.dtype]
+    ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
 
-# Save argparse settings
-save_args(args, out_dir)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = os.path.join(args.out_dir, timestamp)
+    os.makedirs(out_dir, exist_ok=True)
+    save_args(args, out_dir)
 
-# model
-if args.init_from == 'resume':
-    # init from a model saved in a specific directory
-    ckpt_path = os.path.join(args.out_dir, 'ckpt.pt')
-    checkpoint = torch.load(ckpt_path, map_location=args.device)
-    checkpoint['model_args']['dropout'] = 0.0 # typically we don't want dropout during inference
-    gptconf = GPTConfig(**checkpoint['model_args'])
-    print(checkpoint['model_args'])
-    model = GPT(gptconf)
-    state_dict = checkpoint['model']
-    unwanted_prefix = '_orig_mod.'
-    for k,v in list(state_dict.items()):
-        if k.startswith(unwanted_prefix):
-            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
-    model.load_state_dict(state_dict)
-elif args.init_from.startswith('gpt2'):
-    # init from a given GPT-2 model
-    model = GPT.from_pretrained(args.init_from, dict(dropout=0.0))
-
-model.eval()
-model.to(args.device)
-if args.compile:
-    model = torch.compile(model) # requires PyTorch 2.0 (optional)
-
-# Update block size if specified
-if args.block_size:
-    model.update_block_size(args.block_size)
-
-# Update num_angles if specified
-if args.sym_rot_num_angles:
-    model.update_num_angles(args.sym_rot_num_angles)
-
-# look for the meta pickle in case it is available in the dataset folder
-load_meta = False
-separator_token = None
-if args.init_from == 'resume' and 'config' in checkpoint and 'dataset' in checkpoint['config']: # older checkpoints might not have these...
-    meta_path = os.path.join('data', checkpoint['config']['dataset'], 'meta.pkl')
-    load_meta = os.path.exists(meta_path)
-if load_meta:
-    print(f"Loading meta from {meta_path}...")
-    with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
-    if 'tokenizer' in meta and meta['tokenizer'] == 'tiktoken':
-        enc = tiktoken.get_encoding(meta['tiktoken_encoding'])
-        print(f"using tiktoken encoding {meta['tiktoken_encoding']}")
-        encode = lambda s: enc.encode(s, allowed_special={"<|endoftext|>"})
-        decode = lambda l: enc.decode(l)
-    elif 'tokenizer' in meta and meta['tokenizer'] == 'sentencepiece':
-        separator_token = "▁"
-        stoi, itos = meta['stoi'], meta['itos']
-        encode = lambda s: [stoi[c] for c in s]
-        decode = lambda l: ''.join([itos[i] for i in l])
+    if args.init_from == 'resume':
+        ckpt_path = os.path.join(args.out_dir, 'ckpt.pt')
+        checkpoint = torch.load(ckpt_path, map_location=args.device)
+        checkpoint['model_args']['dropout'] = 0.0
+        gptconf = GPTConfig(**checkpoint['model_args'])
+        model = GPT(gptconf)
+        state_dict = checkpoint['model']
+        unwanted_prefix = '_orig_mod.'
+        for k, v in list(state_dict.items()):
+            if k.startswith(unwanted_prefix):
+                state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
+        model.load_state_dict(state_dict)
     else:
-        stoi, itos = meta['stoi'], meta['itos']
-        encode = lambda s: [stoi[c] for c in s]
-        decode = lambda l: ''.join([itos[i] for i in l])
+        model = GPT.from_pretrained(args.init_from, dict(dropout=0.0))
 
-# encode the beginning of the prompt
-if args.start.startswith('FILE:'):
-    with open(args.start[5:], 'r', encoding='utf-8') as f:
-        args.start = f.read()
-start_ids = encode(args.start)
+    model.eval()
+    model.to(args.device)
+    if args.compile:
+        model = torch.compile(model)
 
-if args.interactive:
-    # Run interactive generation
-    interactive_generation(model, start_ids, args.device, args.max_new_tokens, args.temperature, args.top_k, args.stop_string, decode, encode)
-else:
-    x = torch.tensor(start_ids, dtype=torch.long, device=args.device)[None, ...]
+    if args.block_size:
+        model.update_block_size(args.block_size)
 
-    # run generation
-    with torch.no_grad():
-        with ctx:
-            for k in range(args.num_samples):
-                block_size = args.block_size if args.block_size else model.config.block_size
-                for step in range(args.max_new_tokens):
-                    idx_cond = x if x.size(1) <= block_size else x[:, -block_size:]
-                    logits, _ = model(idx_cond)
-                    logits = logits[:, -1, :] / args.temperature
-                    if args.top_k is not None:
-                        v, _ = torch.topk(logits, min(args.top_k, logits.size(-1)))
-                        logits[logits < v[:, [-1]]] = -float('Inf')
-                    probs = F.softmax(logits, dim=-1)
-                    idx_next = torch.multinomial(probs, num_samples=1)
-                    x = torch.cat((x, idx_next), dim=1)
+    if args.sym_rot_num_angles:
+        model.update_num_angles(args.sym_rot_num_angles)
 
-                    if args.show_heatmaps:
-                        selected_token = decode([idx_next[0].item()])
-                        save_chart(probs, x, decode, step, out_dir, args.last_k_tokens, args.chart_type, selected_token)
+    load_meta = False
+    separator_token = None
+    if args.init_from == 'resume' and 'config' in checkpoint and 'dataset' in checkpoint['config']:
+        meta_path = os.path.join('data', checkpoint['config']['dataset'], 'meta.pkl')
+        load_meta = os.path.exists(meta_path)
+    if load_meta:
+        print(f"Loading meta from {meta_path}...")
+        with open(meta_path, 'rb') as f:
+            meta = pickle.load(f)
+        if 'tokenizer' in meta and meta['tokenizer'] == 'tiktoken':
+            enc = tiktoken.get_encoding(meta['tiktoken_encoding'])
+            print(f"using tiktoken encoding {meta['tiktoken_encoding']}")
+            encode = lambda s: enc.encode(s, allowed_special={""})
+            decode = lambda l: enc.decode(l)
+        elif 'tokenizer' in meta and meta['tokenizer'] == 'sentencepiece':
+            separator_token = "▁"
+            stoi, itos = meta['stoi'], meta['itos']
+            encode = lambda s: [stoi[c] for c in s]
+            decode = lambda l: ''.join([itos[i] for i in l])
+        else:
+            stoi, itos = meta['stoi'], meta['itos']
+            encode = lambda s: [stoi[c] for c in s]
+            decode = lambda l: ''.join([itos[i] for i in l])
 
-                output_line = decode(x[0].tolist()).replace(separator_token, " ") if separator_token else decode(x[0].tolist())
-                print("[bold green]" + output_line)
-                print('---------------')
-                if args.sample_file:
-                    with open(args.sample_file, "a") as file:
-                        file.write(output_line)
+    if args.start.startswith('FILE:'):
+        with open(args.start[5:], 'r', encoding='utf-8') as f:
+            args.start = f.read()
+    start_ids = encode(args.start)
+
+    if args.interactive:
+        interactive_generation(model, start_ids, args.device, args.max_new_tokens, args.temperature, args.top_k, args.stop_string, decode, encode)
+    else:
+        x = torch.tensor(start_ids, dtype=torch.long, device=args.device)[None, ...]
+
+        # run generation
+        with torch.no_grad():
+            with ctx:
+                for k in range(args.num_samples):
+                    block_size = args.block_size if args.block_size else model.config.block_size
+                    for step in range(args.max_new_tokens):
+                        idx_cond = x if x.size(1) <= block_size else x[:, -block_size:]
+                        logits, _ = model(idx_cond)
+                        logits = logits[:, -1, :] / args.temperature
+                        if args.top_k is not None:
+                            v, _ = torch.topk(logits, min(args.top_k, logits.size(-1)))
+                            logits[logits < v[:, [-1]]] = -float('Inf')
+                        probs = F.softmax(logits, dim=-1)
+                        idx_next = torch.multinomial(probs, num_samples=1)
+                        x = torch.cat((x, idx_next), dim=1)
+
+                        if args.show_heatmaps:
+                            selected_token = decode([idx_next[0].item()])
+                            save_chart(probs, x, decode, step, out_dir, args.last_k_tokens, args.chart_type, selected_token)
+
+                    output_line = decode(x[0].tolist()).replace(separator_token, " ") if separator_token else decode(x[0].tolist())
+                    print("[bold green]" + output_line)
+                    print('---------------')
+                    if args.sample_file:
+                        with open(args.sample_file, "a") as file:
+                            file.write(output_line)
+
+
+if __name__ == "__main__":
+    main()
 

--- a/train.py
+++ b/train.py
@@ -118,6 +118,7 @@ def parse_args():
 
     # POSITIONAL EMBEDDING VARIATIONS
     model_group.add_argument('--use_rotary_embeddings', default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument('--sym_rot_num_angles', type=int, default=512, help="number of angles to use for symmetric rope variant")
     model_group.add_argument("--rope_variant", type=str, default="rope", choices=["shortrope", "rope"])
     model_group.add_argument("--shortrope_length", type=int, default="16", help="number of embeddings to use with rope, must be <= length, and be even")
     model_group.add_argument('--use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
Several upgrades for sample.py:

- increased block size (context length), necessary for testing and verifying both FIRE and rotary embeddings.
- settable num_angles for symmetric rope variation
- graphs and images to illustrate next token generation
- each time sample.py runs, a folder in the same directory as the ckpt.pt file will be created with settings and (optional) graphs of the inference