### PR TITLE
Add embedding table factorization

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -7,6 +7,7 @@ class GPTConfig:
     n_layer: int = 12
     n_head: int = 12
     n_kv_group: int = 12
+    n_embd_table: int = 768
     n_embd: int = 768
     dropout: float = 0.0
     window_size: int = 128

--- a/model.py
+++ b/model.py
@@ -101,7 +101,7 @@ class CausalSelfAttention(nn.Module):
         # regularization
         self.attn_dropout = nn.Dropout(config.dropout)
         self.resid_dropout = nn.Dropout(config.dropout)
-        self.n_embd = config.n_embd
+        self.n_embd_table = config.n_embd_table
         self.dropout = config.dropout
         self.window_size = config.window_size
         self.n_embd = config.n_embd
@@ -326,7 +326,6 @@ class Block(nn.Module):
                 x = x + self.mlp(self.ln_2(x))
         return x
 
-
 class GPT(nn.Module):
 
     def __init__(self, config):
@@ -336,7 +335,7 @@ class GPT(nn.Module):
 
         self.config = config
 
-        # Initialize and set ouptut normalization (e.g. rmsnorm)
+        # Initialize and set output normalization (e.g., rmsnorm)
         self.norm_variant_output = norm_dictionary[config.norm_variant_output](config)
 
         # Shared Parameters MLP
@@ -344,35 +343,42 @@ class GPT(nn.Module):
         # Shared Parameters Attention
         shared_attn_array = create_shared_param_group("attn", config)
 
+        # Add a new linear layer to scale n_embd_table to n_embd and back
+        self.n_embd = config.n_embd
+        self.n_embd_table = config.n_embd_table
+        self.scale_up = nn.Linear(config.n_embd_table, config.n_embd, bias=False)
+        self.scale_down = nn.Linear(config.n_embd_table, config.n_embd, bias=False)
+        self.scale_up.weight = self.scale_down.weight  # https://paperswithcode.com/method/weight-tying
+        # self.scale_linear_transposed.weight = self.scale_linear.weight.t()
+
         self.transformer = nn.ModuleDict(dict(
-            wte = nn.Embedding(config.vocab_size, config.n_embd),
-            wpe = nn.Embedding(config.block_size, config.n_embd),
+            wte = nn.Embedding(config.vocab_size, config.n_embd_table),
+            wpe = nn.Embedding(config.block_size, config.n_embd_table),
+            sup = self.scale_up,
             drop = nn.Dropout(config.dropout),
             h = nn.ModuleList([Block(config, mlp=shared_mlp_array[i], attn=shared_attn_array[i]) for i in range(config.n_layer)]),
+            sdown = self.scale_down,
             ln_f = self.norm_variant_output,
         ))
+
 
         # Select softmax variant for output layer
         self.softmax_variant_output = config.softmax_variant_output
         if self.softmax_variant_output != "softmax":
             self.softmax_layer_output = softmax_dictionary[config.softmax_variant_output](config)
 
-        self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
-        # with weight tying when using torch.compile() some warnings get generated:
-        # "UserWarning: functional_call was passed multiple values for tied weights.
-        # This behavior is deprecated and will be an error in future versions"
-        # not 100% sure what this is, so far seems to be harmless. TODO investigate
-        self.transformer.wte.weight = self.lm_head.weight # https://paperswithcode.com/method/weight-tying
+        self.lm_head = nn.Linear(self.n_embd_table, config.vocab_size, bias=False)
+        self.transformer.wte.weight = self.lm_head.weight  # https://paperswithcode.com/method/weight-tying
 
-        # init all weights
+        # Initialize all weights
         self.apply(self._init_weights)
-        # apply special scaled init to the residual projections, per GPT-2 paper
+        # Apply special scaled init to the residual projections, per GPT-2 paper
         for pn, p in self.named_parameters():
             if pn.endswith('c_proj.weight'):
-                torch.nn.init.normal_(p, mean=0.0, std=0.02/math.sqrt(2 * config.n_layer))
+                torch.nn.init.normal_(p, mean=0.0, std=0.02 / math.sqrt(2 * config.n_layer))
 
-        # report number of parameters
-        print("number of parameters: %.2fM" % (self.get_num_params()/1e6,))
+        # Report the number of parameters
+        print("number of parameters: %.2fM" % (self.get_num_params() / 1e6,))
 
     def get_num_params(self, non_embedding=True):
         """
@@ -398,30 +404,35 @@ class GPT(nn.Module):
         device = idx.device
         b, t = idx.size()
         assert t <= self.config.block_size, f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
-        pos = torch.arange(0, t, dtype=torch.long, device=device) # shape (t)
+        pos = torch.arange(0, t, dtype=torch.long, device=device)  # shape (t)
 
-        # forward the GPT model itself
-        tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
+        # Forward the GPT model itself
+        tok_emb = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
         x = None
         if self.config.use_abs_pos_embeddings:
-          pos_emb = self.transformer.wpe(pos) # position embeddings of shape (t, n_embd)
-          x = self.transformer.drop(tok_emb + pos_emb)
+            pos_emb = self.transformer.wpe(pos)  # position embeddings of shape (t, n_embd)
+            pos_emb = pos_emb.unsqueeze(0).expand(b, t, -1)  # Modify this line
+            combined_emb = tok_emb + pos_emb  # Add this line
+            x = self.transformer.drop(self.scale_up(combined_emb))  # Modify this line
+
         else:
-          x = self.transformer.drop(tok_emb)
+            x = self.transformer.drop(self.transformer.sup(tok_emb))
         for block in self.transformer.h:
             x = block(x)
         x = self.transformer.ln_f(x)
+        x = torch.matmul(x, self.transformer.sdown.weight)
 
         if targets is not None:
-            # if we are given some desired targets also calculate the loss
+            # If we are given some desired targets, also calculate the loss
             logits = self.lm_head(x)
             loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
         else:
-            # inference-time mini-optimization: only forward the lm_head on the very last position
-            logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
+            # Inference-time mini-optimization: only forward the lm_head on the very last position
+            logits = self.lm_head(x[:, [-1], :])  # Note: using list [-1] to preserve the time dim
             loss = None
 
         return logits, loss
+
 
     def crop_block_size(self, block_size):
         # model surgery to decrease the block size if necessary

--- a/train.py
+++ b/train.py
@@ -55,6 +55,7 @@ def parse_args():
     model_group.add_argument('--n_layer', default=6, type=int)
     model_group.add_argument('--n_head', default=6, type=int)
     model_group.add_argument('--n_kv_group', default=6, type=int)
+    model_group.add_argument('--n_embd_table', default=64, type=int)
     model_group.add_argument('--n_embd', default=384, type=int)
     model_group.add_argument('--dropout', default=0.2, type=float)
     model_group.add_argument('--use_post_ln', default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
This will be important for the next stage of vector inputs.

Currently this already has an advantage for reusing existing tokenizers, making the n_embed size and the vocab table size independent.

This is accomplished by factorizing the vocab table into a vocab table with a smaller dimension and an expansion nn.Linear (e.g. size 50k * 64 matrix multiplied by a 64* 384 matrix for nanoGPT).

The process is reversed in the output, reducing the number of parameters greatly for smaller models.

Though the reduction comes with a cost of some validation loss does decrease, it does provide an avenue to pursue larger tokenizers (e.g. 100k tiktoken or
 256k gemma), with a smaller sized llms.

Decoupling vocab table size from the embedding vector size has another advantage for vector tokenization, where we can provide a feature engineered vocab table, and expand to n_embd with the expansion matrix.

This means that we can  utilize a smaller vector that is feature engineered (say 10 - 20) for csv values and other time series values, while having a much larger embedding vector size for the main network.

This prevents our model from being bottlenecked expressiveness wise (as found with certain papers in the final embedding vector size from the final decoder block).

Otherwise 10 engineered features in a vector approach to tokenization would yield an embedding vector size of only 10, which will then highly bottlenecking the modeling capability.