### PR TITLE
Add scripts creating compatibility for additional dataset

### DIFF
--- a/data/python-codes-25k/README.md
+++ b/data/python-codes-25k/README.md
@@ -1,0 +1,25 @@
+# Python-Codes-25K
+
+This directory contains scripts compatible with python-codes-25k.
+
+## Running scripts
+
+To run the processing scripts do:
+```sh
+bash get_dataset.sh
+```
+
+## Example input.txt:
+
+The scripts will automatically parse the dataset into the following format:
+
+![](./images/example.png)
+
+## Links
+
+https://www.kaggle.com/datasets/patteg21/python-codes-25k-json
+https://huggingface.co/datasets/flytech/python-codes-25k
+
+## License
+
+Hugginface dataset reports the license as MIT

--- a/data/python-codes-25k/get_dataset.sh
+++ b/data/python-codes-25k/get_dataset.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+### Instructions:
+# 1. Replace "INSERT_URL_WITH_FILES" with the actual URL to the Parquet files.
+# 2. Modify the "include_keys" array to specify the keys you want to include in the output.
+# 3. (Optionally) Modify the "value_prefixes" array to set prefixes for each value, use "" for empty prefixes
+# 4. Set "--skip_empty" to true if you want to skip empty fields, or false if not needed.
+# 5. Set "--no_output_text" to true if you plan to process the intermediate json files in a custom manner.
+
+# Run the Python script with the specified arguments
+
+# Add url with dataset here:
+url="https://huggingface.co/datasets/flytech/python-codes-25k/tree/main"
+
+# uncomment and fill in if url has json datasets
+# Note: the $'\n' syntax allows for special characters like \n
+python3 ./utils/get_json_dataset.py \
+  --url "${url}" \
+  --include_keys "instruction" "input" "output" \
+  --value_prefix $'#U:\n' $'#B:\n' $'\n'

--- a/data/python-codes-25k/prepare.py
+++ b/data/python-codes-25k/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/python-codes-25k/utils
+++ b/data/python-codes-25k/utils
@@ -1,0 +1,1 @@
+../template/utils


### PR DESCRIPTION
(This branches from the Vizier PR)

Adding scripts compatible with python-codes-25k, which is an instruction following python dataset of MIT license.