### PR TITLE
Add quantized krmsnorm

### DIFF
--- a/explorations/krmsnorm.json
+++ b/explorations/krmsnorm.json
@@ -1,0 +1,9 @@
+[
+    {
+        "krmsnorm_quantize_type": ["int8", "int16", "none"],
+        "krmsnorm_num": [25, 50, 100, 256],
+        "krmsnorm_enable_gain": [true, false],
+        "krmsnorm_selection_type": ["first", "last", "random"]
+    }
+]
+

--- a/explorations/krmsnorm.json
+++ b/explorations/krmsnorm.json
@@ -1,5 +1,6 @@
 [
     {
+        "norm_variant_attn": ["krmsnorm"],
         "krmsnorm_quantize_type": ["int8", "int16", "none"],
         "krmsnorm_num": ["25", "50", "100", "256"],
         "krmsnorm_enable_gain": [true, false],

--- a/explorations/krmsnorm.json
+++ b/explorations/krmsnorm.json
@@ -1,7 +1,7 @@
 [
     {
         "krmsnorm_quantize_type": ["int8", "int16", "none"],
-        "krmsnorm_num": [25, 50, 100, 256],
+        "krmsnorm_num": ["25", "50", "100", "256"],
         "krmsnorm_enable_gain": [true, false],
         "krmsnorm_selection_type": ["first", "last", "random"]
     }

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -106,6 +106,9 @@ class GPTConfig:
     bias: bool = False # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
     prmsnorm_pct: float = 0.0625
     krmsnorm_num: float = 10
+    krmsnorm_quantize_type: str = 'int8'
+    krmsnorm_enable_gain: bool = True
+    krmsnorm_selection_type: str = 'last'
 
     # Activation Alternatives
     activation_variant: str = "gelu"

--- a/train.py
+++ b/train.py
@@ -80,7 +80,7 @@ def parse_args():
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
     model_group.add_argument("--prmsnorm_pct", default=0.0625, type=float, help="percentage (1 being 100 percent) of first entries used for partial rms" )
     model_group.add_argument("--krmsnorm_num", default=10, type=int, help="max number of first entries for partial rms" )
-    model_group.add_argument("--krmsnorm_quantize_type", type=str, default="int8", choices=["int8", "int16"])
+    model_group.add_argument("--krmsnorm_quantize_type", type=str, default="int8", choices=["int8", "int16", "none"])
     model_group.add_argument('--krmsnorm_enable_gain', default=True, action=argparse.BooleanOptionalAction, help="include gain in kRMSNorm")
     model_group.add_argument("--krmsnorm_selection_type", type=str, default="last", choices=["first", "last", "random"])
 

--- a/train.py
+++ b/train.py
@@ -749,6 +749,18 @@ class Trainer:
                 print(f"step {self.iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
                 self.log_metrics(losses, lr, running_mfu, self.iter_num)
 
+                if math.isnan(losses["val"]):
+                    checkpoint = {
+                        'model': self.raw_model.state_dict(),
+                        'optimizer': self.optimizer.state_dict(),
+                        'model_args': self.model_args,
+                        'iter_num': self.iter_num,
+                        'best_val_loss': self.best_val_loss,
+                        'nan_iter_num' : 0,
+                        'nan' : True,
+                        'config': vars(self.args),
+                    }
+                    torch.save(checkpoint, os.path.join(self.args.out_dir, 'ckpt.pt'))
                 if losses['val'] < self.best_val_loss or self.args.always_save_checkpoint:
                     if losses['val'] < self.best_val_loss:
                         self.iter_num_best_val_loss = self.iter_num

--- a/train.py
+++ b/train.py
@@ -80,7 +80,7 @@ def parse_args():
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
     model_group.add_argument("--prmsnorm_pct", default=0.0625, type=float, help="percentage (1 being 100 percent) of first entries used for partial rms" )
     model_group.add_argument("--krmsnorm_num", default=10, type=int, help="max number of first entries for partial rms" )
-    model_group.add_argument("--krmsnorm_quantize_type", type=str, default="int8", choices=["int8", "int16", "none"])
+    model_group.add_argument("--krmsnorm_quantize_type", type=str, default="none", choices=["int8", "int16", "none"])
     model_group.add_argument('--krmsnorm_enable_gain', default=True, action=argparse.BooleanOptionalAction, help="include gain in kRMSNorm")
     model_group.add_argument("--krmsnorm_selection_type", type=str, default="last", choices=["first", "last", "random"])
 

--- a/train.py
+++ b/train.py
@@ -80,6 +80,9 @@ def parse_args():
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
     model_group.add_argument("--prmsnorm_pct", default=0.0625, type=float, help="percentage (1 being 100 percent) of first entries used for partial rms" )
     model_group.add_argument("--krmsnorm_num", default=10, type=int, help="max number of first entries for partial rms" )
+    model_group.add_argument("--krmsnorm_quantize_type", type=str, default="int8", choices=["int8", "int16"])
+    model_group.add_argument('--krmsnorm_enable_gain', default=True, action=argparse.BooleanOptionalAction, help="include gain in kRMSNorm")
+    model_group.add_argument("--krmsnorm_selection_type", type=str, default="last", choices=["first", "last", "random"])
 
     # ACTIVATION VARIATIONS
     model_group.add_argument(

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -50,25 +50,63 @@ class pRMSNorm(nn.Module):
         return x / prms * self.gain
 
 class kRMSNorm(nn.Module):
-    """First k elements RMS Normalization"""
+    """First k elements RMS Normalization with optional int8/int16 quantization and configurable gain"""
 
     def __init__(self, config):
         super().__init__()
         ndim = config.n_embd
-        self.gain = nn.Parameter(torch.ones(ndim))
-        self.k = config.krmsnorm_num # percent of elements to use
+        self.gain = nn.Parameter(torch.ones(ndim)) if config.enable_gain else None
+        self.k = config.krmsnorm_num
+        self.quantize_type = config.quantize_type  # 'int8' or 'int16'
+        self.enable_gain = config.enable_gain
+
+    def quantize(self, x, dtype):
+        if dtype == 'int8':
+            qmin, qmax = -128, 127
+            scale = (x.max() - x.min()) / (qmax - qmin)
+            zero_point = qmin - x.min() / scale
+            x_q = (x / scale + zero_point).clamp(qmin, qmax).round().to(torch.int8)
+        elif dtype == 'int16':
+            qmin, qmax = -32768, 32767
+            scale = (x.max() - x.min()) / (qmax - qmin)
+            zero_point = qmin - x.min() / scale
+            x_q = (x / scale + zero_point).clamp(qmin, qmax).round().to(torch.int16)
+        else:
+            raise ValueError("Unsupported quantization type")
+        return x_q, scale, zero_point
+
+    def dequantize(self, x_q, scale, zero_point, dtype):
+        if dtype in ['int8', 'int16']:
+            x = (x_q.to(torch.float32) - zero_point) * scale
+        else:
+            raise ValueError("Unsupported quantization type")
+        return x
 
     def forward(self, x):
-        # Calculate the number of elements to use for pRMS
+        # Calculate the number of elements to use for kRMS
         k = min(x.size(-1), self.k)
 
         # Select the first k elements along the last dimension
         x_part = x[..., :k]
 
-        # Calculate kRMS
-        krms = x_part.norm(2, dim=-1, keepdim=True) / math.sqrt(k)
+        # Quantize x_part
+        x_part_q, scale, zero_point = self.quantize(x_part, self.quantize_type)
 
-        return x / krms * self.gain
+        # Calculate kRMS on quantized values
+        krms = x_part_q.float().norm(2, dim=-1, keepdim=True) / math.sqrt(k)
+
+        # Dequantize the krms
+        krms = self.dequantize(krms, scale, zero_point, self.quantize_type)
+
+        # Apply normalization
+        x = x / krms
+
+        # Apply gain if enabled
+        if self.enable_gain:
+            x = x * self.gain
+
+        return x
+
 
 norm_dictionary = {
     "layernorm": LayerNorm,

--- a/variations/norm_variations.py
+++ b/variations/norm_variations.py
@@ -55,11 +55,11 @@ class kRMSNorm(nn.Module):
     def __init__(self, config):
         super().__init__()
         ndim = config.n_embd
-        self.gain = nn.Parameter(torch.ones(ndim)) if config.enable_gain else None
+        self.gain = nn.Parameter(torch.ones(ndim)) if config.krmsnorm_enable_gain else None
         self.k = config.krmsnorm_num
-        self.quantize_type = config.quantize_type  # 'int8', 'int16', or 'none'
-        self.enable_gain = config.enable_gain
-        self.selection_type = config.selection_type  # 'first', 'last', or 'random'
+        self.quantize_type = config.krmsnorm_quantize_type  # 'int8', 'int16', or 'none'
+        self.enable_gain = config.krmsnorm_enable_gain
+        self.selection_type = config.krmsnorm_selection_type  # 'first', 'last', or 'random'
 
     def quantize(self, x, dtype):
         if dtype == 'int8':


### PR DESCRIPTION
This adds more options for kRMSNorm:

- optional gain parameters (can simplify hardware)
- different quantizations with zero points and scaling factors (currently int8, int16, and none)
- more selection strategies - first k, last k, or random k

And a configuration sweep json to search through the settings space for krmsnorm including krmsnorm_num.