### PR TITLE
Weight pruning and visualization of weight mask / pruned weights

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -12,6 +12,7 @@ class GPTConfig:
     dropout: float = 0.0
     window_size: int = 128
     gate: bool = False
+    prune: bool = False
 
     # Training options
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower


### PR DESCRIPTION
Added one argument "--prune", to enable model pruning after training and accuracy computation in train.py

Added arguments in sample.py, "--prune_percentage" to specify the percentage of weights to prune, and reused previous code to visualize weights/weight mask:

Pruned weights:
![layer_0_weights (4)](https://github.com/user-attachments/assets/e5e62e09-e3ca-4caa-acb3-352e2d616532)

Weight mask: 
![transformer h 0 mlp c_proj_weight_mask](https://github.com/user-attachments/assets/babc99f9-3a62-4b4f-92e7-5612ffc0f30f)



