### PR TITLE
Add Mixture of Experts (MoE) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ csv_logs/
 # checkpoint directories
 out*/
 .aider*
+
+venv/*

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -15,6 +15,8 @@ class GPTConfig:
     use_moe: bool = False
     moe_layer_freq: int = 2
     n_experts: int = 8
+    moe_top_k: int = 2
+    moe_router_scheme: str = "softmax"
 
 
     # Training options

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -12,6 +12,8 @@ class GPTConfig:
     dropout: float = 0.0
     window_size: int = 128
     gate: bool = False
+    moe: bool = False
+    moe_layer_freq: int = 2
 
     # Training options
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -12,10 +12,10 @@ class GPTConfig:
     dropout: float = 0.0
     window_size: int = 128
     gate: bool = False
-    moe: bool = False
+    use_moe: bool = False
     moe_layer_freq: int = 2
     n_experts: int = 8
-    
+
 
     # Training options
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -14,6 +14,8 @@ class GPTConfig:
     gate: bool = False
     moe: bool = False
     moe_layer_freq: int = 2
+    n_experts: int = 8
+    
 
     # Training options
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower

--- a/model.py
+++ b/model.py
@@ -30,6 +30,9 @@ from variations.activation_variations import activation_dictionary
 from variations.linear_variations import linear_dictionary
 
 def create_shared_param_group(layer_type, config):
+
+    # explore MoE layers being reflected symmetrically
+
     shared_size = None
     shared_sym = None # if true, output array is symmetrical
     layer_block = None
@@ -372,7 +375,6 @@ class GPT(nn.Module):
             moduleList = []
             for i in range(config.n_layer):
                 if i % self.config.moe_layer_freq == 0:
-                    # TODO: replace the 'mlp=' with an MoE Layer
                     moduleList.append(Block(config, mlp=MoELayer(config), attn=shared_attn_array[i]))
                 else:
                     moduleList.append(Block(config, mlp=shared_mlp_array[i], attn=shared_attn_array[i]))
@@ -702,7 +704,6 @@ class NoisyTopKGatingNetwork(nn.Module):
     def forward(self, mh_output):
         # print(f"mh_output shape: {mh_output.shape}")
 
-        # TODO : uncomment once support for multiple router schemes 
         if self.moe_router_scheme == 'softmax':
             return self.softmaxGatingForward(mh_output)
         elif self.moe_router_scheme == 'noisy_top_k':

--- a/model.py
+++ b/model.py
@@ -318,6 +318,11 @@ class Block(nn.Module):
         else:
             self.mlp = mlp
 
+        if config.moe:
+            # overriding the block's MLP FFN layer with composited MoE layer (router -> [experts])
+            #   easier to leverage identical forward pass
+            self.mlp = MoELayer(config)
+
     def forward(self, x):
         def custom_forward(*inputs):
             x = inputs[0]
@@ -368,7 +373,7 @@ class GPT(nn.Module):
             for i in range(config.n_layer):
                 if i % self.config.moe_layer_freq == 0:
                     # TODO: replace the 'mlp=' with an MoE Layer
-                    moduleList.append(Block(config, mlp=shared_mlp_array[i], attn=shared_attn_array[i]))
+                    moduleList.append(Block(config, mlp=MoELayer(config), attn=shared_attn_array[i]))
                 else:
                     moduleList.append(Block(config, mlp=shared_mlp_array[i], attn=shared_attn_array[i]))
 

--- a/model.py
+++ b/model.py
@@ -322,11 +322,6 @@ class Block(nn.Module):
         else:
             self.mlp = mlp
 
-        if config.use_moe:
-            # overriding the block's MLP FFN layer with composited MoE layer (router -> [experts])
-            #   easier to leverage identical forward pass
-            self.mlp = MoELayer(config)
-
     def forward(self, x):
         def custom_forward(*inputs):
             x = inputs[0]

--- a/model.py
+++ b/model.py
@@ -710,8 +710,6 @@ class NoisyTopKGatingNetwork(nn.Module):
         else:
             print(f"ERROR: unknown MoE router scheme {self.gating_scheme} found")
 
-        return router_output, indices
-
 
 class MoELayer(nn.Module):
     """ Mixture of Experts layer to replace FFN (or every other FFN) """

--- a/train.py
+++ b/train.py
@@ -58,6 +58,8 @@ def parse_args():
     model_group.add_argument('--use_post_ln', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--window_size', default=None, type=int, help="Sliding window size, note this cannot be greater than block size")
     model_group.add_argument('--gate', default=False, action=argparse.BooleanOptionalAction, help="option for gated attention see https://arxiv.org/abs/2306.12929")
+    model_group.add_argument('--moe', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Experts (MoE) architecture")
+    model_group.add_argument('--moe_layer_freq', default=2, type=int)
 
     ## MLP Options
     model_group.add_argument('--use_parallel_mlp', default=False, action=argparse.BooleanOptionalAction)
@@ -381,6 +383,8 @@ class Trainer:
 
             self.load_data()
             gptconf = GPTConfig(**self.model_args)
+            print("GPT CONF:: ")
+            print(gptconf)
             self.model = GPT(gptconf)
             self.iter_num = 0 # for starting from scratch
             self.best_val_loss = 1e9 # really big number

--- a/train.py
+++ b/train.py
@@ -61,6 +61,8 @@ def parse_args():
     model_group.add_argument('--use_moe', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Experts (MoE) architecture")
     model_group.add_argument('--moe_layer_freq', default=2, type=int, help="set frequency for replacing FFNs with MoE layers")
     model_group.add_argument('--n_experts', default=8, type=int, help="set number of experts per MoE layer")
+    model_group.add_argument('--moe_top_k', default=2, type=int)
+    model_group.add_argument('--moe_router_scheme', default="softmax", type=str, help="option to set routing scheme for MoE layer, defaults to softmax")
 
     ## MLP Options
     model_group.add_argument('--use_parallel_mlp', default=False, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -404,11 +404,7 @@ class Trainer:
 
             self.load_data()
             gptconf = GPTConfig(**self.model_args)
-            print("GPT CONF:: ")
-            print(gptconf)
             self.model = GPT(gptconf)
-            print("MODEL: ")
-            print(self.model)
             self.iter_num = 0 # for starting from scratch
             self.best_val_loss = 1e9 # really big number
         elif self.args.init_from == 'resume':

--- a/train.py
+++ b/train.py
@@ -58,8 +58,9 @@ def parse_args():
     model_group.add_argument('--use_post_ln', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--window_size', default=None, type=int, help="Sliding window size, note this cannot be greater than block size")
     model_group.add_argument('--gate', default=False, action=argparse.BooleanOptionalAction, help="option for gated attention see https://arxiv.org/abs/2306.12929")
-    model_group.add_argument('--moe', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Experts (MoE) architecture")
-    model_group.add_argument('--moe_layer_freq', default=2, type=int)
+    model_group.add_argument('--use_moe', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Experts (MoE) architecture")
+    model_group.add_argument('--moe_layer_freq', default=2, type=int, help="set frequency for replacing FFNs with MoE layers")
+    model_group.add_argument('--n_experts', default=8, type=int, help="set number of experts per MoE layer")
 
     ## MLP Options
     model_group.add_argument('--use_parallel_mlp', default=False, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -389,6 +389,8 @@ class Trainer:
             print("GPT CONF:: ")
             print(gptconf)
             self.model = GPT(gptconf)
+            print("MODEL: ")
+            print(self.model)
             self.iter_num = 0 # for starting from scratch
             self.best_val_loss = 1e9 # really big number
         elif self.args.init_from == 'resume':

--- a/variations/router_variations.py
+++ b/variations/router_variations.py
@@ -1,0 +1,54 @@
+import math
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+class TopKRouter(nn.Module):
+    """ Conventional Softmax Top_k Gating network (router) NN for MoE layers """
+    def __init__(self, config):
+        super().__init__()
+        self.top_k = config.moe_top_k
+        self.moe_router_scheme = config.moe_router_scheme
+        self.route_linear = nn.Linear(config.n_embd, config.n_experts)
+    
+    def forward(self, x):
+        logits = self.route_linear(x)
+
+        top_k_logits, indices = logits.topk(self.top_k, dim=-1)
+        zeros = torch.full_like(logits, float('-inf')) 
+        
+        sparse_logits = zeros.scatter(-1, indices, top_k_logits)
+        router_output= F.softmax(sparse_logits, dim=-1)
+
+        return router_output, indices
+
+
+class NoisyTopKRouter(nn.Module):
+    """ Noisy Top_k Gating network (router) NN for MoE layers """
+    def __init__(self, config):
+        super().__init__()
+        self.top_k = config.moe_top_k
+        self.moe_router_scheme = config.moe_router_scheme
+        self.route_linear = nn.Linear(config.n_embd, config.n_experts)
+        self.noise_linear = nn.Linear(config.n_embd, config.n_experts)
+
+    def forward(self, x):
+        logits = self.route_linear(x)
+
+        noise_logits = self.noise_linear(x)
+        noise = torch.randn_like(logits)*F.softplus(noise_logits)
+        
+        top_k_noisy_logits = noise_logits + noise
+        top_k_logits, indices = logits.topk(self.top_k, dim=1)
+        
+        zeros = torch.full_like(top_k_noisy_logits, float('-inf'))
+        sparse_logits = zeros.scatter(-1, indices, top_k_logits)
+        
+        router_output = F.softmax(sparse_logits, dim=-1)
+
+        return router_output, indices
+
+router_dictionary = {
+    "softmax": TopKRouter,
+    "noisy_top_k": NoisyTopKRouter,
+}


### PR DESCRIPTION
Opening a draft PR for adding Mixture of Experts (MoE) support. The primary changes in this PR are: 
1) adding new class for Gating Network (aka Router Network)
2) adding new class for MoE layer which combines a single Gating Network in front of an array of MLPs called "experts"
3) modify the Block class to accept "moe" flag and replace generic MLPs with an MoE layer
4) modify the GPT class to build Blocks with alternating MoE and MLP layers based on input flags
5) adding cmd line flags for using MoE architecture