### PR TITLE
Add ability to save quantized weights/activations, scale factors, and zero points

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -187,33 +187,6 @@ class GPTConfig:
     quantize_linear_mlp_down_bits: int = None
     quantization_warmup_iters: int = 100
 
-    ## Activation Quantizations
-    activations_quant_method: str = "affine_quant"
-    quantize_attn_act: bool = False
-    quantize_attn_act_bits: int = 8
-    quantize_attn_act_input: bool = False
-    quantize_attn_act_input_bits: int = None
-    quantize_attn_act_qk_mult_input: bool = False
-    quantize_attn_act_qk_mult_input_bits: int = None
-    quantize_attn_act_softmax_input: bool = False
-    quantize_attn_act_softmax_input_bits: int = None
-    quantize_attn_act_pv_mult_input: bool = False
-    quantize_attn_act_pv_mult_input_bits: int = None
-    quantize_attn_act_pv_mult_output: bool = False
-    quantize_attn_act_pv_mult_output_bits: int = None
-    quantize_attn_act_output: bool = False
-    quantize_attn_act_output_bits: int = None
-    quantize_mlp_act: bool = False
-    quantize_mlp_act_bits: int = 8
-    quantize_mlp_act_input: bool = False
-    quantize_mlp_act_input_bits: int = None
-    quantize_mlp_act_activation_input: bool = False
-    quantize_mlp_act_activation_input_bits: int = None
-    quantize_mlp_act_activation_output: bool = False
-    quantize_mlp_act_activation_output_bits: int = None
-    quantize_mlp_act_output: bool = False
-    quantize_mlp_act_output_bits: int = None
-
     @classmethod
     def from_json(cls, filename: str):
         try:

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -169,6 +169,7 @@ class GPTConfig:
     quantize_mlp_act_activation_output_bits: int = None
     quantize_mlp_act_output: bool = False
     quantize_mlp_act_output_bits: int = None
+    update_activations: bool = False
 
     ## Linear Quantizations
     quantize_linear_method: str = "affine_quant"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -169,7 +169,7 @@ class GPTConfig:
     quantize_mlp_act_activation_output_bits: int = None
     quantize_mlp_act_output: bool = False
     quantize_mlp_act_output_bits: int = None
-    update_activations: bool = False
+    store_activations: bool = False
 
     ## Linear Quantizations
     quantize_linear_method: str = "affine_quant"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -187,6 +187,33 @@ class GPTConfig:
     quantize_linear_mlp_down_bits: int = None
     quantization_warmup_iters: int = 100
 
+    ## Activation Quantizations
+    activations_quant_method: str = "affine_quant"
+    quantize_attn_act: bool = False
+    quantize_attn_act_bits: int = 8
+    quantize_attn_act_input: bool = False
+    quantize_attn_act_input_bits: int = None
+    quantize_attn_act_qk_mult_inputs: bool = False
+    quantize_attn_act_qk_mult_inputs_bits: int = None
+    quantize_attn_act_softmax_input: bool = False
+    quantize_attn_act_softmax_input_bits: int = None
+    quantize_attn_act_pv_mult_inputs: bool = False
+    quantize_attn_act_pv_mult_inputs_bits: int = None
+    quantize_attn_act_pv_mult_output: bool = False
+    quantize_attn_act_pv_mult_output_bits: int = None
+    quantize_attn_act_output: bool = False
+    quantize_attn_act_output_bits: int = None
+    quantize_mlp_act: bool = False
+    quantize_mlp_act_bits: int = 8
+    quantize_mlp_act_input: bool = False
+    quantize_mlp_act_input_bits: int = None
+    quantize_mlp_act_activation_input: bool = False
+    quantize_mlp_act_activation_input_bits: int = None
+    quantize_mlp_act_activation_output: bool = False
+    quantize_mlp_act_activation_output_bits: int = None
+    quantize_mlp_act_output: bool = False
+    quantize_mlp_act_output_bits: int = None
+
     @classmethod
     def from_json(cls, filename: str):
         try:

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -193,12 +193,12 @@ class GPTConfig:
     quantize_attn_act_bits: int = 8
     quantize_attn_act_input: bool = False
     quantize_attn_act_input_bits: int = None
-    quantize_attn_act_qk_mult_inputs: bool = False
-    quantize_attn_act_qk_mult_inputs_bits: int = None
+    quantize_attn_act_qk_mult_input: bool = False
+    quantize_attn_act_qk_mult_input_bits: int = None
     quantize_attn_act_softmax_input: bool = False
     quantize_attn_act_softmax_input_bits: int = None
-    quantize_attn_act_pv_mult_inputs: bool = False
-    quantize_attn_act_pv_mult_inputs_bits: int = None
+    quantize_attn_act_pv_mult_input: bool = False
+    quantize_attn_act_pv_mult_input_bits: int = None
     quantize_attn_act_pv_mult_output: bool = False
     quantize_attn_act_pv_mult_output_bits: int = None
     quantize_attn_act_output: bool = False

--- a/model.py
+++ b/model.py
@@ -111,6 +111,7 @@ class CausalSelfAttention(nn.Module):
             # Set each attention Activation precision and method
             if arg.startswith("quantize_") and "attn_act" in arg and arg.endswith("_bits"):
                 self.quantization_attn_dict[arg] = set_variant(val, config.quantize_attn_act_bits)
+            # If the setting is an activation bool, default set to the value of config.quantize_attn_act
             elif arg.startswith("quantize_") and "attn_act" in arg:
                 self.quantization_attn_dict[arg] = set_variant(val, config.quantize_attn_act)
                 if arg != "quantize_attn_act" and self.quantization_attn_dict[arg]:

--- a/model.py
+++ b/model.py
@@ -111,7 +111,6 @@ class CausalSelfAttention(nn.Module):
             # Set each attention Activation precision and method
             if arg.startswith("quantize_") and "attn_act" in arg and arg.endswith("_bits"):
                 self.quantization_attn_dict[arg] = set_variant(val, config.quantize_attn_act_bits)
-            # If the setting is an activation bool, default set to the value of config.quantize_attn_act
             elif arg.startswith("quantize_") and "attn_act" in arg:
                 self.quantization_attn_dict[arg] = set_variant(val, config.quantize_attn_act)
                 if arg != "quantize_attn_act" and self.quantization_attn_dict[arg]:

--- a/model.py
+++ b/model.py
@@ -111,7 +111,6 @@ class CausalSelfAttention(nn.Module):
                 self.quantization_attn_dict[arg] = set_variant(val, config.quantize_attn_act)
                 if config.store_activations and arg != "quantize_attn_act" and self.quantization_attn_dict[arg]:
                     arg_str = arg.split("quantize_")[1]
-                    self.quantization_activations = {}
                     if arg_str == "attn_act_qk_mult_input":
                         self.register_buffer(f"{arg_str}_q", None)
                         self.register_buffer(f"{arg_str}_q_scale", None)

--- a/quantization/quantize.py
+++ b/quantization/quantize.py
@@ -109,6 +109,13 @@ def dequantize(zero_point, scale, tensor):
     """
     return (tensor - zero_point) * scale
 
+def fake_quantize_act(obj, activation, tensor, num_bits, quant_method):
+    act, scale, zero_point = quantize_dictionary[quant_method](tensor, num_bits)
+    setattr(obj, activation, act)
+    setattr(obj, f"{activation}_scale", scale)
+    setattr(obj, f"{activation}_zero_point", zero_point)
+    return dequantize(act, scale, zero_point)
+
 class FakeLinearQuantizationFunction(torch.autograd.Function):
     """Simulates error caused by quantization. Uses Straight-Through Estimator for Back prop
     Source: https://github.com/Alexstrasza98/Transformer-Quantization/blob/main

--- a/quantization/quantize.py
+++ b/quantization/quantize.py
@@ -110,11 +110,11 @@ def dequantize(zero_point, scale, tensor):
     return (tensor - zero_point) * scale
 
 def fake_quantize_act(obj, activation, tensor, num_bits, quant_method):
-    act, scale, zero_point = quantize_dictionary[quant_method](tensor, num_bits)
+    zero_point, scale, act = quantize_dictionary[quant_method](tensor, num_bits)
     setattr(obj, activation, act)
     setattr(obj, f"{activation}_scale", scale)
     setattr(obj, f"{activation}_zero_point", zero_point)
-    return dequantize(act, scale, zero_point)
+    return dequantize(zero_point, scale, act)
 
 class FakeLinearQuantizationFunction(torch.autograd.Function):
     """Simulates error caused by quantization. Uses Straight-Through Estimator for Back prop

--- a/sample.py
+++ b/sample.py
@@ -12,6 +12,7 @@ import torch
 import tiktoken
 from rich import print
 from torch.nn import functional as F
+from collections import OrderedDict
 
 from model import GPT, GPTConfig
 
@@ -20,6 +21,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Inference from trained models")
     parser.add_argument("--device", type=str, required=True, help="Device to run inference (e.g., 'cpu', 'cuda', 'cuda:0', 'cuda:1')")
     parser.add_argument("--out_dir", type=str, required=True, help="Directory to load checkpoint from")
+    parser.add_argument("--quantization_data_file", type=str, default=None, help="File name to export the quantized weights/activations, scale factor, and zero point")
     parser.add_argument("--init_from", type=str, default="resume", help="Either 'resume' (from an out_dir) or a GPT-2 variant (e.g., 'gpt2-xl')")
     parser.add_argument("--start", type=str, default="\n", help="Start text for generation. Can specify a file using 'FILE:prompt.txt'")
     parser.add_argument("--num_samples", type=int, default=3, help="Number of inference streams to draw")
@@ -89,6 +91,16 @@ def save_args(args, out_dir):
         json.dump(vars(args), f, indent=4)
 
 
+def save_quantized_data(state_dict, out_file):
+    to_save = OrderedDict()
+    for k, v in list(state_dict.items()):
+        if "mlp_act" in k or "attn_act" in k or k.endswith("quantized_bias") or k.endswith("bias_norm") or k.endswith("zero_point") or k.endswith("quantized_weight") or k.endswith("weight_norm"):
+            to_save[k] = v.cpu().numpy()
+
+    with open(f"{out_file}.pkl", 'wb') as f:
+        pickle.dump(to_save, f)
+
+
 def main():
     args = parse_args()
 
@@ -116,7 +128,11 @@ def main():
         for k, v in list(state_dict.items()):
             if k.startswith(unwanted_prefix):
                 state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
-        model.load_state_dict(state_dict)
+
+        if args.quantization_data_file:
+            save_quantized_data(state_dict, args.quantization_data_file)
+
+        model.load_state_dict(state_dict, strict=False)
     else:
         model = GPT.from_pretrained(args.init_from, dict(dropout=0.0))
 

--- a/train.py
+++ b/train.py
@@ -190,7 +190,7 @@ def parse_args():
     model_group.add_argument("--quantize_mlp_act_output_bits", type=int, default=None, help="number of bits for mlp output quantization")
 
     ### Whether activations should be saved
-    model_group.add_argument("--update_activations", action=argparse.BooleanOptionalAction, default=False, help="whether the activations should be saved as a buffer and updated through training")
+    model_group.add_argument("--store_activations", action=argparse.BooleanOptionalAction, default=False, help="whether the activations should be saved as a buffer and updated through training")
     
     ## Linear Attn Weight Quantization Precision and Method 
     

--- a/train.py
+++ b/train.py
@@ -188,6 +188,9 @@ def parse_args():
     model_group.add_argument("--quantize_mlp_act_activation_input_bits", type=int, default=None, help="number of bits for activation function input quantization")
     model_group.add_argument("--quantize_mlp_act_activation_output_bits", type=int, default=None, help="number of bits for activation function output quantization")
     model_group.add_argument("--quantize_mlp_act_output_bits", type=int, default=None, help="number of bits for mlp output quantization")
+
+    ### Whether activations should be saved
+    model_group.add_argument("--update_activations", action=argparse.BooleanOptionalAction, default=False, help="whether the activations should be saved as a buffer and updated through training")
     
     ## Linear Attn Weight Quantization Precision and Method 
     


### PR DESCRIPTION
In sample.py, added new --quantization_data_file argument that allows you to save a ordered dictionary of numpy arrays to a pkl file. These arrays include quantized weights/activations, scale factors, and zero points depending on which activations and linears were quantized. 