### PR TITLE
Add implementation of Rotary Embeddings

### DIFF
--- a/explorations/rope_sweep.json
+++ b/explorations/rope_sweep.json
@@ -1,0 +1,19 @@
+[
+    {
+        "max_iters": ["5000"],
+        "n_layer": ["6"],
+        "n_kv_group": ["6"],
+        "n_head": ["6"],
+        "n_embd": ["384"],
+        "block_size":["256"],
+        "device": ["cuda"],
+        "dtype": ["float16"],
+        "dataset": ["shakespeare_char"],
+        "use_rotary_embeddings": [true, false],
+        "rope_variant": ["soap", "rope"],
+        "use_abs_pos_embeddings": [false],
+        "use_fire_embeddings": [false],
+        "compile": [true],
+    }
+]
+

--- a/explorations/rope_sweep.json
+++ b/explorations/rope_sweep.json
@@ -5,15 +5,30 @@
         "n_kv_group": ["6"],
         "n_head": ["6"],
         "n_embd": ["384"],
+        "eval_interval": ["50"],
         "block_size":["256"],
         "device": ["cuda"],
         "dtype": ["float16"],
         "dataset": ["shakespeare_char"],
-        "use_rotary_embeddings": [true, false],
-        "rope_variant": ["soap", "rope"],
+        "use_rotary_embeddings": [true],
         "use_abs_pos_embeddings": [false],
         "use_fire_embeddings": [false],
         "compile": [true],
+        "seed": {
+          "range": {
+            "start": 1337,
+            "end": 1537,
+            "step": 100
+          }
+        },
+        "rope_variant": ["soap", "rope"],
+        "rope_length": {
+          "range": {
+            "start": 2,
+            "end": 64,
+            "step": 2
+          }
+        }
     }
 ]
 

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -96,7 +96,7 @@ class GPTConfig:
     use_rotary_embeddings: bool = False
     sym_rot_num_angles: int = 512
     rope_variant: str = "rope" # options: "shortrope", "rope"
-    shortrope_length: int = 8 # number of embeddings to use in shortrope
+    rope_length: int = 8 # number of embeddings to use in shortrope
 
     ## Embedding Intialization Options
     embedding_mean_init: float= 0.0

--- a/inspect_ckpts.py
+++ b/inspect_ckpts.py
@@ -3,15 +3,19 @@ import os
 import torch
 import csv
 import re
+import time
 from rich.console import Console
 from rich.table import Table
 
-def get_best_val_loss_and_iter_num(target_file, args):
+def get_best_val_loss_and_iter_num(target_file, args, max_retries=5, retry_interval=2):
     """
-    Extracts the best validation loss and the corresponding iteration number from a PyTorch checkpoint file, unless 'best_val_loss_and_iter.txt' exists.
+    Extracts the best validation loss and the corresponding iteration number from a PyTorch checkpoint file,
+    retrying if the file is incomplete or corrupted.
 
     Args:
         checkpoint_file (str): Path to the PyTorch checkpoint file.
+        max_retries (int): Maximum number of retries if loading fails.
+        retry_interval (int): Time (in seconds) to wait before retrying.
 
     Returns:
         float: The best validation loss.
@@ -19,6 +23,7 @@ def get_best_val_loss_and_iter_num(target_file, args):
     """
     best_val_loss = "No Data"
     iter_num = "No Data"
+
     if args.fast:
         if os.path.exists(target_file):
             with open(target_file, "r") as file:
@@ -32,21 +37,34 @@ def get_best_val_loss_and_iter_num(target_file, args):
         training_nan_iter = "No Data"
         return best_val_loss, iter_num, training_nan, training_nan_iter
     else:
-        # Load the checkpoint on CPU
-        checkpoint = torch.load(target_file, map_location=torch.device('cpu'))
-        best_val_loss = checkpoint['best_val_loss']
-        iter_num = checkpoint['iter_num']
+        attempts = 0
+        while attempts < max_retries:
+            try:
+                # Load the checkpoint on CPU
+                checkpoint = torch.load(target_file, map_location=torch.device('cpu'))
+                best_val_loss = checkpoint['best_val_loss']
+                iter_num = checkpoint['iter_num']
 
-        training_nan = None
-        training_nan_iter = None
-        if args.inspect_nan:
-            if 'nan' in checkpoint:
-                training_nan = checkpoint['nan']
-                training_nan_iter = checkpoint['nan_iter_num']
-            else:
-                training_nan = "No Data"
-                training_nan_iter = "No Data"
+                training_nan = None
+                training_nan_iter = None
+                if args.inspect_nan:
+                    if 'nan' in checkpoint:
+                        training_nan = checkpoint['nan']
+                        training_nan_iter = checkpoint['nan_iter_num']
+                    else:
+                        training_nan = "No Data"
+                        training_nan_iter = "No Data"
 
+                return best_val_loss, iter_num, training_nan, training_nan_iter
+            except RuntimeError as e:
+                print(f"Error loading {target_file}: {e}")
+                print(f"Retrying in {retry_interval} seconds... ({attempts + 1}/{max_retries})")
+                attempts += 1
+                time.sleep(retry_interval)
+
+        # If all retries fail, return "No Data"
+        training_nan = "No Data"
+        training_nan_iter = "No Data"
         return best_val_loss, iter_num, training_nan, training_nan_iter
 
 def find_target_files(directory, target_string="ckpt.pt", path_regex=None):
@@ -88,19 +106,16 @@ def get_shortname_target_file(ckpt_file, n_fields=None, target_string="ckpt.pt")
             return '-'.join(fields[-n_fields:])
     return ckpt_file
 
-def main():
-    parser = argparse.ArgumentParser(description='Extract best validation loss and iteration number from PyTorch checkpoint files.')
-    parser.add_argument('--inspect_nan', default=False, action=argparse.BooleanOptionalAction)
-    parser.add_argument('--directory', type=str, default=".", help='Path to the directory containing the checkpoint files.')
-    parser.add_argument('--csv_file', type=str, help='Path to the CSV file containing the checkpoint data.')
-    parser.add_argument('--path_regex', type=str, help='Regular expression to filter the checkpoint file paths.')
-    parser.add_argument('--sort', type=str, choices=['path', 'loss', 'iter', 'nan', 'nan_iter'], default='path', help='Sort the table by checkpoint file path, best validation loss, or iteration number.')
-    parser.add_argument('--reverse', action='store_true', help='Reverse the sort order.')
-    parser.add_argument('--output', type=str, help='Path to the output CSV file.')
-    parser.add_argument('--n_fields', type=int, help='Number of fields to display from the end of the checkpoint file path.')
-    parser.add_argument('--fast', action='store_true', help='only look for validation loss files from out_dirs')
-    args = parser.parse_args()
+def load_checkpoint_data(args):
+    """
+    Load checkpoint data from either a directory or a CSV file.
 
+    Args:
+        args (Namespace): Parsed command-line arguments.
+
+    Returns:
+        list: A list of tuples containing checkpoint data.
+    """
     if args.csv_file:
         ckpt_data = []
         with open(args.csv_file, 'r') as csvfile:
@@ -120,39 +135,48 @@ def main():
                     ckpt_data.append((get_shortname_target_file(row[0]), float(row[1]), int(row[2])))
     elif args.fast:
         target_files = find_target_files(args.directory, target_string="best_val_loss_and_iter.txt", path_regex=args.path_regex)
-
-        # Extract the best validation loss and iteration number for each checkpoint file
         ckpt_data = [(get_shortname_target_file(target_file, target_string="best_val_loss_and_iter.txt"),
                       *get_best_val_loss_and_iter_num(target_file, args)) for target_file in target_files]
     elif args.directory:
         ckpt_files = find_target_files(args.directory, target_string="ckpt.pt", path_regex=args.path_regex)
-        # Extract the best validation loss and iteration number for each checkpoint file
         ckpt_data = [(get_shortname_target_file(ckpt_file),
                       *get_best_val_loss_and_iter_num(ckpt_file, args)) for ckpt_file in ckpt_files]
     else:
         print("Please provide either a directory or a CSV file.")
-        return
+        return []
 
-    # Sort the data based on the specified sort option
-    if args.sort == 'path':
-        ckpt_data.sort(key=lambda x: x[0], reverse=args.reverse)
-    elif args.sort == 'loss':
-        ckpt_data.sort(key=lambda x: x[1], reverse=args.reverse)
-    elif args.sort == 'iter':
-        ckpt_data.sort(key=lambda x: x[2], reverse=args.reverse)
-    elif args.sort == 'nan':
-        ckpt_data.sort(key=lambda x: x[3], reverse=args.reverse)
-    elif args.sort == 'nan_iter':
-        ckpt_data.sort(key=lambda x: x[4], reverse=args.reverse)
+    return ckpt_data
 
-    console = None
-    # Check if the TERM environment variable is set to a value that supports ANSI escape codes
-    if 'TERM' in os.environ and os.environ['TERM'] in ['xterm', 'xterm-color', 'xterm-256color', 'screen', 'screen-256color', 'tmux', 'tmux-256color']:
-        console = Console(color_system="standard")
-    else:
-        console = Console()
+def sort_checkpoint_data(ckpt_data, sort_key, reverse):
+    """
+    Sort the checkpoint data based on the specified sort key.
 
-    # Determine the maximum length of the checkpoint file paths
+    Args:
+        ckpt_data (list): The checkpoint data to sort.
+        sort_key (str): The key to sort by ('path', 'loss', 'iter', 'nan', 'nan_iter').
+        reverse (bool): Whether to reverse the sort order.
+
+    Returns:
+        list: The sorted checkpoint data.
+    """
+    sort_keys = {
+        'path': lambda x: x[0],
+        'loss': lambda x: x[1],
+        'iter': lambda x: x[2],
+        'nan': lambda x: x[3],
+        'nan_iter': lambda x: x[4]
+    }
+    return sorted(ckpt_data, key=sort_keys[sort_key], reverse=reverse)
+
+def display_checkpoint_data(ckpt_data, args):
+    """
+    Display the checkpoint data in a table format using Rich library.
+
+    Args:
+        ckpt_data (list): The checkpoint data to display.
+        args (Namespace): Parsed command-line arguments.
+    """
+    console = Console(color_system="standard")
     max_path_length = max(len(ckpt_file) for ckpt_file, _, _, _, _ in ckpt_data)
 
     table = Table(show_header=True, header_style="bold blue")
@@ -163,28 +187,61 @@ def main():
         table.add_column("NaN Result", justify="right")
         table.add_column("NaN Iter Num", justify="right")
 
-    if args.output:
-        with open(args.output, 'w', newline='') as csvfile:
-            csv_writer = csv.writer(csvfile)
-            csv_writer.writerow(["Checkpoint File", "Best Validation Loss", "Iteration Number", "NaN", "Nan Iter"])
-            if args.inspect_nan:
-                for ckpt_file, best_val_loss, iter_num, training_nan, training_nan_iter in ckpt_data:
-                    table.add_row(ckpt_file, f"{best_val_loss:.4f}", str(iter_num), str(training_nan), str(training_nan_iter))
-                    csv_writer.writerow([ckpt_file, f"{best_val_loss:.4f}", str(iter_num), str(training_nan), str(training_nan_iter)])
-            else:
-                for ckpt_file, best_val_loss, iter_num in ckpt_data:
-                    table.add_row(ckpt_file, f"{best_val_loss:.4f}", str(iter_num))
-                    csv_writer.writerow([ckpt_file, f"{best_val_loss:.4f}", str(iter_num)])
-            print(f"Results exported to {args.output}")
-    else:
+    for ckpt_file, best_val_loss, iter_num, training_nan, training_nan_iter in ckpt_data:
+        row = [ckpt_file, f"{best_val_loss:.4f}", str(iter_num)]
         if args.inspect_nan:
-            for ckpt_file, best_val_loss, iter_num, training_nan, training_nan_iter in ckpt_data:
-                table.add_row(ckpt_file, f"{best_val_loss:.4f}", str(iter_num), str(training_nan), str(training_nan_iter))
-        else:
-            for ckpt_file, best_val_loss, iter_num, _, _ in ckpt_data:
-                table.add_row(ckpt_file, f"{best_val_loss:.4f}", str(iter_num))
+            row.extend([str(training_nan), str(training_nan_iter)])
+        table.add_row(*row)
 
     console.print(table)
+
+def export_checkpoint_data_to_csv(ckpt_data, output_path, args):
+    """
+    Export the checkpoint data to a CSV file.
+
+    Args:
+        ckpt_data (list): The checkpoint data to export.
+        output_path (str): The path to the output CSV file.
+        args (Namespace): Parsed command-line arguments.
+    """
+    with open(output_path, 'w', newline='') as csvfile:
+        csv_writer = csv.writer(csvfile)
+        headers = ["Checkpoint File", "Best Validation Loss", "Iteration Number"]
+        if args.inspect_nan:
+            headers.extend(["NaN", "Nan Iter"])
+        csv_writer.writerow(headers)
+
+        for ckpt_file, best_val_loss, iter_num, training_nan, training_nan_iter in ckpt_data:
+            row = [ckpt_file, f"{best_val_loss:.4f}", str(iter_num)]
+            if args.inspect_nan:
+                row.extend([str(training_nan), str(training_nan_iter)])
+            csv_writer.writerow(row)
+
+    print(f"Results exported to {output_path}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Extract best validation loss and iteration number from PyTorch checkpoint files.')
+    parser.add_argument('--inspect_nan', default=False, action=argparse.BooleanOptionalAction)
+    parser.add_argument('--directory', type=str, default=".", help='Path to the directory containing the checkpoint files.')
+    parser.add_argument('--csv_file', type=str, help='Path to the CSV file containing the checkpoint data.')
+    parser.add_argument('--path_regex', type=str, help='Regular expression to filter the checkpoint file paths.')
+    parser.add_argument('--sort', type=str, choices=['path', 'loss', 'iter', 'nan', 'nan_iter'], default='path', help='Sort the table by checkpoint file path, best validation loss, or iteration number.')
+    parser.add_argument('--reverse', action='store_true', help='Reverse the sort order.')
+    parser.add_argument('--output', type=str, help='Path to the output CSV file.')
+    parser.add_argument('--n_fields', type=int, help='Number of fields to display from the end of the checkpoint file path.')
+    parser.add_argument('--fast', action='store_true', help='only look for validation loss files from out_dirs')
+    args = parser.parse_args()
+
+    ckpt_data = load_checkpoint_data(args)
+    if not ckpt_data:
+        return
+
+    ckpt_data = sort_checkpoint_data(ckpt_data, args.sort, args.reverse)
+
+    if args.output:
+        export_checkpoint_data_to_csv(ckpt_data, args.output, args)
+    else:
+        display_checkpoint_data(ckpt_data, args)
 
 if __name__ == "__main__":
     main()

--- a/inspect_ckpts.py
+++ b/inspect_ckpts.py
@@ -57,8 +57,6 @@ def get_best_val_loss_and_iter_num(target_file, args, max_retries=5, retry_inter
 
                 return best_val_loss, iter_num, training_nan, training_nan_iter
             except RuntimeError as e:
-                print(f"Error loading {target_file}: {e}")
-                print(f"Retrying in {retry_interval} seconds... ({attempts + 1}/{max_retries})")
                 attempts += 1
                 time.sleep(retry_interval)
 

--- a/model.py
+++ b/model.py
@@ -159,14 +159,14 @@ class CausalSelfAttention(nn.Module):
         if config.use_rotary_embeddings:
             # TODO update variant name after completing rope and shortrope updates
             # TODO Add shortrope to symmetrical rope
-            if config.rope_variant == "rope":
+            if config.rope_variant == "soap":
                 self.sym_rot_num_angles = config.sym_rot_num_angles
                 self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd, num_angles=self.sym_rot_num_angles)
                 self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=self.kv_dim, num_angles=self.sym_rot_num_angles)
-            # TODO update rope and shortrope to accomodate new GQA additions
-            # if config.rope_variant == "rope":
-            #     self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd)
-            #     self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // config.n_head * config.n_kv_group)
+            elif config.rope_variant == "rope":
+                # TODO update rope and shortrope to accomodate new GQA additions
+                self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd)
+                self.rotary_emb_k = RotaryEmbedding(config, size=self.kv_dim)
             # if config.rope_variant == "shortrope":
             #     self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd)
             #     self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // config.n_head * config.n_kv_group)

--- a/model.py
+++ b/model.py
@@ -551,6 +551,13 @@ class GPT(nn.Module):
                 block.attn.rotary_emb_q.update_num_angles(num_angles, device)
                 block.attn.rotary_emb_k.update_num_angles(num_angles, device)
 
+    def update_rope_length(self, rope_length):
+        """Update the number of angles for rotary embeddings in all attention layers."""
+        for block in self.transformer.h:
+            if hasattr(block.attn, 'rotary_emb_q') and hasattr(block.attn, 'rotary_emb_k'):
+                block.attn.rotary_emb_q.update_rope_length(rope_length)
+                block.attn.rotary_emb_k.update_rope_length(rope_length)
+
 
     def forward(self, idx, targets=None):
         device = idx.device

--- a/model.py
+++ b/model.py
@@ -25,7 +25,7 @@ import torch.utils.checkpoint as checkpoint
 # Variations
 from variations.softmax_variations import softmax_dictionary
 from variations.norm_variations import norm_dictionary
-from variations.position_encoding_variations import QuantizedEmbedding, RotaryEmbedding, ShortRope, SymmetricalOverlapAngularPositions, FIRE
+from variations.position_encoding_variations import QuantizedEmbedding, RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
 from variations.activation_variations import activation_dictionary
 from variations.linear_variations import linear_dictionary
 from variations.router_variations import router_dictionary
@@ -157,19 +157,14 @@ class CausalSelfAttention(nn.Module):
         self.rotary_emb_q = None
         self.rotary_emb_k = None
         if config.use_rotary_embeddings:
-            # TODO update variant name after completing rope and shortrope updates
-            # TODO Add shortrope to symmetrical rope
+            # Note: size is the size of the head dimension
             if config.rope_variant == "soap":
                 self.sym_rot_num_angles = config.sym_rot_num_angles
-                self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd, num_angles=self.sym_rot_num_angles)
-                self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=self.kv_dim, num_angles=self.sym_rot_num_angles)
+                self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
+                self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
             elif config.rope_variant == "rope":
-                # TODO update rope and shortrope to accomodate new GQA additions
-                self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd)
-                self.rotary_emb_k = RotaryEmbedding(config, size=self.kv_dim)
-            # if config.rope_variant == "shortrope":
-            #     self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd)
-            #     self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // config.n_head * config.n_kv_group)
+                self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+                self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
 
         # Softmax Variant Selection
         self.softmax_variant_attn = config.softmax_variant_attn
@@ -215,10 +210,6 @@ class CausalSelfAttention(nn.Module):
         k = self.c_attn_k(x)
         v = self.c_attn_v(x)
 
-        if self.rotary_emb_q is not None:
-            q = self.rotary_emb_q(q)
-            k = self.rotary_emb_k(k)
-
         if self.window_size is not None:
             window_mask = torch.ones((1, 1, T, T), device=x.device)
             window_mask = torch.triu(window_mask, diagonal=-self.window_size)
@@ -246,6 +237,11 @@ class CausalSelfAttention(nn.Module):
         q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, n_h, T, hs)
         k = k.view(B, T, self.n_kv_group, C // self.n_head).transpose(1, 2) # (B, n_kv, T, hs)
         v = v.view(B, T, self.n_kv_group, C // self.n_head).transpose(1, 2) # (B, n_kv, T, hs)
+
+        # rotate q and k before evaluating with the heads
+        if (self.rotary_emb_q is not None) and (self.rotary_emb_k is not None):
+            q = self.rotary_emb_q(q)
+            k = self.rotary_emb_k(k)
 
         y = None
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)

--- a/rope_sweep.json
+++ b/rope_sweep.json
@@ -1,0 +1,22 @@
+[
+    {
+        "max_iters": ["3000"],
+        "block_size":["256"],
+        "device": ["cuda"],
+        "dtype": ["float16"],
+        "dataset": ["shakespeare_char"],
+        "use_rotary_embeddings": [true],
+        "rope_variant": ["rope","soap"],
+        "rope_length": {
+          "range": {
+            "start": 2,
+            "end": 64,
+            "step": 2
+          }
+        },
+        "use_abs_pos_embeddings": [false],
+        "use_fire_embeddings": [false],
+        "compile": [true]
+    }
+]
+

--- a/sample.py
+++ b/sample.py
@@ -37,6 +37,7 @@ def parse_args():
     parser.add_argument('--chart_type', type=str, default='heatmap', choices=['heatmap', 'barchart'], help="Type of chart to display: 'heatmap' or 'barchart'")
     parser.add_argument('--block_size', type=int, default=None, help="Block size for context length, default is model's block size")
     parser.add_argument('--sym_rot_num_angles', type=int, default=None, help="Number of angles for symmetrical rotary embedding")
+    parser.add_argument('--rope_length', type=int, default=None, help="Number of embeddings to rotate (must be an even number <= total embedding size)")
     parser.add_argument('--token_boundary', type=str, default=None, help="optional separator between emitted tokens")
 
     return parser.parse_args()
@@ -125,11 +126,17 @@ def main():
     if args.compile:
         model = torch.compile(model)
 
+    # Inference with different block size (note: for this one cannot use abs pos embeddings)
     if args.block_size:
         model.update_block_size(args.block_size)
 
+    # Inference with different number of angles
     if args.sym_rot_num_angles:
         model.update_num_angles(args.sym_rot_num_angles)
+
+    # Inference with different Rope Length
+    if args.rope_length:
+        model.update_rope_length(args.rope_length)
 
     load_meta = False
     meta_path = None

--- a/train.py
+++ b/train.py
@@ -220,7 +220,7 @@ def parse_args():
     # POSITIONAL EMBEDDING VARIATIONS
     model_group.add_argument('--use_rotary_embeddings', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--sym_rot_num_angles', type=int, default=512, help="number of angles to use for symmetric rope variant")
-    model_group.add_argument("--rope_variant", type=str, default="rope", choices=["shortrope", "rope"])
+    model_group.add_argument("--rope_variant", type=str, default="rope", choices=["shortrope", "rope", "soap"])
     model_group.add_argument("--shortrope_length", type=int, default="16", help="number of embeddings to use with rope, must be <= length, and be even")
     model_group.add_argument('--use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--use_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -220,8 +220,8 @@ def parse_args():
     # POSITIONAL EMBEDDING VARIATIONS
     model_group.add_argument('--use_rotary_embeddings', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--sym_rot_num_angles', type=int, default=512, help="number of angles to use for symmetric rope variant")
-    model_group.add_argument("--rope_variant", type=str, default="rope", choices=["shortrope", "rope", "soap"])
-    model_group.add_argument("--shortrope_length", type=int, default="16", help="number of embeddings to use with rope, must be <= length, and be even")
+    model_group.add_argument("--rope_variant", type=str, default="rope", choices=["rope", "soap"])
+    model_group.add_argument("--rope_length", type=int, default=None, help="Defaults to all embeddings (if set to None), else must be even.")
     model_group.add_argument('--use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--use_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--shared_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)
@@ -507,6 +507,8 @@ class Trainer:
             self.load_data()
             gptconf = GPTConfig(**self.model_args)
             self.model = GPT(gptconf)
+            ## TODO: Add means here to udpate the resume for: block size (finetune for longer context), rotary type, rope length, softmax type, etc.
+            ## TODO: Add ability here to swap WTE factors.
             state_dict = checkpoint['model']
             for k,v in list(state_dict.items()):
                 if k.startswith('_orig_mod.'):

--- a/variations/position_encoding_variations.py
+++ b/variations/position_encoding_variations.py
@@ -82,6 +82,13 @@ class SymmetricalOverlapAngularPositions(nn.Module):
         assert self.dim % 2 == 0, "Target length dim must be even for rotary embeddings"
 
         self.num_angles = num_angles
+        if self.rope_length != None:
+            self.rope_length = config.rope_length
+            assert self.rope_length % 2 == 0, "Shortrope length must be even"
+            assert self.rope_length <= self.dim, "Shortrope length less than or equal to dim"
+        else:
+            self.rope_length = self.dim
+            assert self.rope_length % 2 == 0, "Embedding dim length must be even for rotary position embeddings"
         self.first_pass = True
         self.angles = None
 
@@ -94,6 +101,11 @@ class SymmetricalOverlapAngularPositions(nn.Module):
         if self.num_angles != num_angles:
             self.num_angles = num_angles
             self.angles = self._generate_angles(num_angles, device)
+
+    def update_rope_length(self, rope_length):
+        """Update the number of angles and regenerate angles tensor if needed."""
+        if self.rope_length != rope_length:
+            self.rope_length = rope_length
 
     def forward(self, x):
         if self.first_pass:
@@ -112,76 +124,26 @@ class SymmetricalOverlapAngularPositions(nn.Module):
         selected_angles = self.angles[angle_indices]
 
         # Run angles through sine and cosine
-        sin_angles = selected_angles.sin().unsqueeze(-1).repeat(1, self.dim // 2)
-        cos_angles = selected_angles.cos().unsqueeze(-1).repeat(1, self.dim // 2)
+        sin_angles = selected_angles.sin().unsqueeze(-1).repeat(1, self.rope_length // 2)
+        cos_angles = selected_angles.cos().unsqueeze(-1).repeat(1, self.rope_length // 2)
 
-        # Split input tensor into even and odd components
-        x_even, x_odd = x[..., ::2], x[..., 1::2]
+        # Split input tensor into even and odd components for the rope length
+        x_even, x_odd = x[..., :self.rope_length:2], x[..., 1:self.rope_length:2]
 
-        # Rotate components
+        # Rotate components for the rope length
         x_rotated_even = x_even * cos_angles - x_odd * sin_angles
         x_rotated_odd = x_even * sin_angles + x_odd * cos_angles
 
         # Reassemble rotated components
         x_combined = torch.empty_like(x, device=device)
-        # TODO shorten x_combined to manually set length, then replace corresponding portion of original x matrix to implement shortrope
-        x_combined[..., ::2], x_combined[..., 1::2] = x_rotated_even, x_rotated_odd
+        x_combined[..., :self.rope_length:2], x_combined[..., 1:self.rope_length:2] = x_rotated_even, x_rotated_odd
+
+        # Keep the rest of the elements unchanged
+        if self.rope_length < self.dim:
+            x_combined[..., self.rope_length:] = x[..., self.rope_length:]
 
         return x_combined
 
-class ShortRope(nn.Module):
-
-    def __init__(self, config):
-        super().__init__()
-        self.n = config.shortrope_length
-        self.dim = config.n_embd
-
-        # Generate freqs of size n rather than full dim
-        self.register_buffer('freq_left', (10000 ** (torch.arange(0, self.n//2).float() / self.n//2)))
-        self.register_buffer('freq_right', (10000 ** (torch.arange(0, self.n//2).float() / self.n//2)))
-
-    def forward(self, x):
-        # Step 1: Get the input tensor shape
-        batch_size, seq_len, _ = x.shape
-
-        # Step 2: Split the input tensor into unrotated and rotated sections
-        x_unrotated = x[..., :-self.n]  # All but the last n dimensions
-        x_rotated = x[..., -self.n:]    # Only the last n dimensions
-
-        # Step 3: Generate rotation frequencies
-        t = torch.arange(self.n, device=x.device)
-        freqs_left = torch.einsum('i,j->ij', t, self.freq_left)
-        freqs_right = torch.einsum('i,j->ij', t, self.freq_right)
-
-        # Calculate how many times to repeat freqs along the sequence length
-        num_repeats = seq_len // self.n + int(seq_len % self.n != 0)
-
-        # Repeat the frequency tensors to match the sequence length
-        freqs_left = freqs_left.repeat(batch_size, num_repeats, 1)
-        freqs_right = freqs_right.repeat(batch_size, num_repeats, 1)
-
-        # Trim the excess elements so the freqs tensors match the sequence length
-        freqs_left = freqs_left[:, :seq_len, :]
-        freqs_right = freqs_right[:, :seq_len, :]
-
-        # Step 4: Process the x_rotated section
-        x_left = x_rotated[..., :self.n//2]
-        x_right = x_rotated[..., self.n//2:]
-
-        # Apply the cosine and sine rotations
-        x_left = x_left * freqs_left.cos() - x_right * freqs_left.sin()
-        x_right = x_left * freqs_right.sin() + x_right * freqs_right.cos()
-
-        # Invert the order of the right tensor's last dimension and negate it
-        x_right = torch.flip(x_right, dims=[-1]) * -1
-
-        # Combine the left and right rotated sections
-        x_rotated = torch.cat([x_left, x_right], dim=-1)
-
-        # Step 5: Combine the rotated and unrotated sections
-        x = torch.cat([x_unrotated, x_rotated], dim=-1)
-
-        return x
 
 class FIRE(nn.Module):
     """


### PR DESCRIPTION
# Rotary Position Embeddings

This is an implementation of standard RoPE based on modifcations of the repo's Symmetrical Rope implementation.

## Testing vs Existing Libraries

Checked this version of rotary embeddings against standard rope, output matches exactly for same inputs.

## Evaluations on Shakespeare with Char and Wikitext103 with Tiktoken

Sharing Image of current standings:
![image](https://github.com/user-attachments/assets/a4c7de0b-3ed1-4f77-81b1-ebe20853db6d)

So far conventional RoPE has the most accurate next token prediction on Shakespeare_char and Wikitext103_Tiktoken.

The difference does get smaller for Wikitext103, suggesting the network with enough time can adapt to use the more memory efficient Symmetrical rope.

## Sweeps

From the sweeps, it appears for now that 512 does the best in terms of the Symmetrical Rope.

We need to test if we increase the max context length if the best number increases (e.g. does 512 do best with 1024 angles?) 

Or is 512 just an ideal angle that the network likes for separation with symmetrical rope approach?

## "Trimmed" Rope

Will try to patch this PR with options for "Trimming" the number of pairs which need to be rotated.

This will potentially save compute and memory for standard rope, and just compute time for symmetrical rope. 