### PR TITLE
MoE expert sharing and freezing support

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -18,7 +18,7 @@ class GPTConfig:
     n_experts: int = 8
     moe_top_k: int = 2
     moe_router_scheme: str = "softmax"
-
+    share_experts: bool = False
 
     # Training options
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -16,7 +16,7 @@ class GPTConfig:
     use_moe: bool = False
     moe_layer_freq: int = 2
     n_experts: int = 8
-    moe_top_k: int = 2
+    moe_top_k: int = 1
     moe_router_scheme: str = "softmax"
     share_experts: bool = False
 

--- a/model.py
+++ b/model.py
@@ -45,9 +45,6 @@ def create_shared_param_group(layer_type, config, experts=None):
     elif layer_type == "attn":
         shared_size = config.shared_attn_size
         shared_sym = config.shared_attn_sym
-    elif layer_type == "moe":
-        shared_size = config.shared_moe_size
-        shared_sym = config.shared_moe_sym
     else:
         sys.exit(f"{layer_type} not supported, exiting")
 

--- a/model.py
+++ b/model.py
@@ -45,6 +45,9 @@ def create_shared_param_group(layer_type, config, experts=None):
     elif layer_type == "attn":
         shared_size = config.shared_attn_size
         shared_sym = config.shared_attn_sym
+    elif layer_type == "moe":
+        shared_size = config.shared_moe_size
+        shared_sym = config.shared_moe_sym
     else:
         sys.exit(f"{layer_type} not supported, exiting")
 
@@ -361,14 +364,8 @@ class GPT(nn.Module):
         # Initialize and set ouptut normalization (e.g. rmsnorm)
         self.norm_variant_output = norm_dictionary[config.norm_variant_output](config)
 
-        # Create shared experts if flagged
-        if config.share_experts:
-            shared_experts = nn.ModuleList([MLP(config) for _ in range(config.n_experts)])
-        else:
-            shared_experts = None
-
         # Shared Parameters MLP
-        shared_mlp_array = create_shared_param_group("mlp", config, experts=shared_experts)
+        shared_mlp_array = create_shared_param_group("mlp", config)
         # Shared Parameters Attention
         shared_attn_array = create_shared_param_group("attn", config)
 

--- a/train.py
+++ b/train.py
@@ -63,6 +63,7 @@ def parse_args():
     model_group.add_argument('--n_experts', default=8, type=int, help="set number of experts per MoE layer")
     model_group.add_argument('--moe_top_k', default=2, type=int)
     model_group.add_argument('--moe_router_scheme', default="softmax", type=str, help="option to set routing scheme for MoE layer, defaults to softmax")
+    model_group.add_argument('--share_experts', default=False,  action=argparse.BooleanOptionalAction, help="option for sharing MoE experts across layers")
 
     ## MLP Options
     model_group.add_argument('--use_parallel_mlp', default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
* Adding support to share experts across MoE layers using command line flag "--share_experts"
* Adding support for freezing expert layers when training from previous run using flag "--freeze_experts" 
* Note: freezing experts is only effective when training from a previous run using the "--prev_run" flag