### PR TITLE
Add MLP Expansion factor control and sweep

### DIFF
--- a/explorations/mlp_expansion_factor_sweep.json
+++ b/explorations/mlp_expansion_factor_sweep.json
@@ -1,0 +1,21 @@
+[
+    {
+      "max_iters": ["3500"],
+      "n_layer": ["4", "6", "8"],
+      "n_head": ["6"],
+      "n_embd": ["384"],
+      "block_size":["256"],
+      "device": ["cuda"],
+      "dataset": ["shakespeare_char"],
+      "compile": [true],
+      "save_nan_checkpoint": [true],
+      "use_rotary_embeddings": [false],
+      "use_abs_pos_embeddings": [true],
+      "mlp_expansion_factor": ["2", "3", "4", "5"],
+      "softmax_variant_attn": ["softmax"],
+      "dtype": ["bfloat16"],
+      "use_parallel_mlp": [true, false],
+      "mlp_variant": ["mlp", "swiglu"]
+    }
+  ]
+

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -30,6 +30,7 @@ class GPTConfig:
     # MLP Options
     use_parallel_mlp: bool = False
     mlp_variant: str = "mlp"
+    mlp_expansion_factor: int = 4
 
     ## KAN Option
     kan_poly_order: int = 3

--- a/train.py
+++ b/train.py
@@ -86,6 +86,7 @@ def parse_args():
     ## MLP Options
     model_group.add_argument('--use_parallel_mlp', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument("--mlp_variant", type=str, default="mlp", choices=["mlp", "kan", "swiglu"], help="MLP variation type")
+    model_group.add_argument("--mlp_expansion_factor", type=int, default=4, help="If MLP like variant is used, set the expansion factor for the linear transformations, default is 4.")
 
     ## KAN Options
     model_group.add_argument("--kan_poly_order", type=int, default=3, help="Order of KAN non-linearity")


### PR DESCRIPTION
Some networks have started experimenting with different expansion factors, here we add a sweep for this testing affects of different mlp settings.