### PR TITLE
add softmax variant IO interval

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -22,7 +22,7 @@ class GPTConfig:
     softmax_io_logging: bool = False
     consmax_beta_gamma_logging: bool = False
     plot_statistics: bool = False
-    softmax_IO_interval: int = 10
+    softmax_io_log_interval: int = 1
 
     # Training options
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -22,6 +22,7 @@ class GPTConfig:
     softmax_io_logging: bool = False
     consmax_beta_gamma_logging: bool = False
     plot_statistics: bool = False
+    softmax_IO_interval: int = 10
 
     # Training options
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower

--- a/train.py
+++ b/train.py
@@ -372,7 +372,7 @@ def parse_args():
 
     # Module And Parameter Logging and Plots of Summary Statistics
     model_group.add_argument('--softmax_io_logging', default=False, action=argparse.BooleanOptionalAction, help="logs inputs and outputs of supported softmaxes")
-    model_group.add_argument('--softmax_io_log_interval', default=10, type=int)
+    model_group.add_argument('--softmax_io_log_interval', default=1, type=int)
     model_group.add_argument('--consmax_beta_gamma_logging', default=False, action=argparse.BooleanOptionalAction, help="logs beta and gamma")
     logging_group.add_argument('--create_statistics', default=False, action=argparse.BooleanOptionalAction)
     logging_group.add_argument('--plot_statistics', default=False, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -45,7 +45,6 @@ def parse_args():
     training_group.add_argument('--out_dir', default='out', type=str)
     training_group.add_argument('--eval_interval', default=250, type=int)
     training_group.add_argument('--log_interval', default=10, type=int)
-    training_group.add_argument('--softmax_IO_interval', default=10, type=int)
     training_group.add_argument('--eval_iters', default=200, type=int)
     training_group.add_argument('--eval_only', default=False, action=argparse.BooleanOptionalAction)
 
@@ -373,6 +372,7 @@ def parse_args():
 
     # Module And Parameter Logging and Plots of Summary Statistics
     model_group.add_argument('--softmax_io_logging', default=False, action=argparse.BooleanOptionalAction, help="logs inputs and outputs of supported softmaxes")
+    model_group.add_argument('--softmax_io_log_interval', default=10, type=int)
     model_group.add_argument('--consmax_beta_gamma_logging', default=False, action=argparse.BooleanOptionalAction, help="logs beta and gamma")
     logging_group.add_argument('--create_statistics', default=False, action=argparse.BooleanOptionalAction)
     logging_group.add_argument('--plot_statistics', default=False, action=argparse.BooleanOptionalAction)
@@ -906,7 +906,7 @@ class Trainer:
                     self.log_metrics_non_validation(lossf, running_mfu, self.iter_num)
 
 
-                if self.args.create_statistics and local_iter_num % self.args.softmax_IO_interval == 0:
+                if self.args.create_statistics and local_iter_num % self.args.softmax_io_log_interval == 0:
                     create_statistics(self, graph_y_labels)
 
 

--- a/train.py
+++ b/train.py
@@ -45,6 +45,7 @@ def parse_args():
     training_group.add_argument('--out_dir', default='out', type=str)
     training_group.add_argument('--eval_interval', default=250, type=int)
     training_group.add_argument('--log_interval', default=10, type=int)
+    training_group.add_argument('--softmax_IO_interval', default=10, type=int)
     training_group.add_argument('--eval_iters', default=200, type=int)
     training_group.add_argument('--eval_only', default=False, action=argparse.BooleanOptionalAction)
 
@@ -905,7 +906,7 @@ class Trainer:
                     self.log_metrics_non_validation(lossf, running_mfu, self.iter_num)
 
 
-                if self.args.create_statistics:
+                if self.args.create_statistics and local_iter_num % self.args.softmax_IO_interval == 0:
                     create_statistics(self, graph_y_labels)
 
 

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -217,8 +217,8 @@ class Strongermax(nn.Module):
         if self.training and self.softmax_io_logging and self.iter_num % self.softmax_IO_interval == 0:
             self.inputs = x
             self.outputs = result
-
-        self.iter_num += 1
+        if self.training:
+            self.iter_num += 1
 
         return result
 

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -170,6 +170,8 @@ class Strongermax(nn.Module):
         self.divisor = config.strongermax_divisor
         self.div_by_seq_len = config.div_by_seq_len
         self.overflow_recompute = config.strongermax_overflow_recompute
+        self.softmax_IO_interval = config.softmax_IO_interval
+        self.iter_num = 0
 
         if self.overflow_recompute:
             assert(self.xmax_guess is not None, "for overflow recompute, xmax_guess must be set") # ensure x_intercept is strictly left of the y-axis
@@ -177,7 +179,7 @@ class Strongermax(nn.Module):
         # Input and Output Logging
         self.softmax_io_logging = config.softmax_io_logging
         print(self.softmax_io_logging)
-        if self.softmax_io_logging:
+        if self.training and self.softmax_io_logging and self.iter_num % self.softmax_IO_interval == 0:
             self.inputs = []
             self.outputs = []
 
@@ -212,9 +214,11 @@ class Strongermax(nn.Module):
 
         result = result / self.divisor
 
-        if self.softmax_io_logging:
+        if self.training and self.softmax_io_logging and self.iter_num % self.softmax_IO_interval == 0:
             self.inputs = x
             self.outputs = result
+
+        self.iter_num += 1
 
         return result
 

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -170,7 +170,7 @@ class Strongermax(nn.Module):
         self.divisor = config.strongermax_divisor
         self.div_by_seq_len = config.div_by_seq_len
         self.overflow_recompute = config.strongermax_overflow_recompute
-        self.softmax_IO_interval = config.softmax_IO_interval
+        self.softmax_io_log_interval = config.softmax_io_log_interval
         self.iter_num = 0
 
         if self.overflow_recompute:
@@ -179,7 +179,7 @@ class Strongermax(nn.Module):
         # Input and Output Logging
         self.softmax_io_logging = config.softmax_io_logging
         print(self.softmax_io_logging)
-        if self.training and self.softmax_io_logging and self.iter_num % self.softmax_IO_interval == 0:
+        if self.training and self.softmax_io_logging and self.iter_num % self.softmax_io_log_interval == 0:
             self.inputs = []
             self.outputs = []
 

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -214,7 +214,7 @@ class Strongermax(nn.Module):
 
         result = result / self.divisor
 
-        if self.training and self.softmax_io_logging and self.iter_num % self.softmax_IO_interval == 0:
+        if self.training and self.softmax_io_logging and self.iter_num % self.softmax_io_log_interval == 0:
             self.inputs = x
             self.outputs = result
         if self.training:


### PR DESCRIPTION
Looks like create_statistics causes a lot of time overhead：
before:
<img width="482" alt="Screen Shot 2024-09-04 at 1 55 17 AM" src="https://github.com/user-attachments/assets/e04b631c-7dd9-45ff-9e5c-2c8b6dd2797b">
After softmax_IO_interval = 10:
<img width="482" alt="Screen Shot 2024-09-04 at 4 03 33 AM" src="https://github.com/user-attachments/assets/2391f0e3-2e3c-4af4-9bd4-0e9c1944075f">

