### PR TITLE
Add pos emb finetuning option

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -128,8 +128,11 @@ class GPTConfig:
     ## Softplus options
     softplus_divisor: float = 256.0
 
-    ## Softplus options
+    ## ReLUMax options
     relumax_divisor: float = 256.0
+
+    ## SigmoidMax options
+    sigmoidmax_divisor: float = 256.0
 
     ## Squareplus options
     squareplus_divisor: float = 256.0

--- a/model.py
+++ b/model.py
@@ -890,6 +890,10 @@ class GPT(nn.Module):
                     if key == "lm_head.weight":
                         continue
 
+                if not config.use_abs_pos_embeddings:
+                    if key == "transformer.wpe.weight":
+                        continue
+
                 assert sd_hf[key].shape == sd[key].shape
                 with torch.no_grad():
                     print(key)

--- a/model.py
+++ b/model.py
@@ -777,10 +777,6 @@ class GPT(nn.Module):
             else:
                 x = block(x)
 
-            # if layer == 6:
-                # select nn.Linear of dimension 1x embedding dimension
-                #x += nn.Linear
-
             # Intercept for Steering Vectors
             if self.config.apply_vector_at_layer_idx is not None and layer == self.config.apply_vector_at_layer_idx:
                 x = self.apply_vector_to_layer_output(x)

--- a/model.py
+++ b/model.py
@@ -777,6 +777,10 @@ class GPT(nn.Module):
             else:
                 x = block(x)
 
+            # if layer == 6:
+                # select nn.Linear of dimension 1x embedding dimension
+                #x += nn.Linear
+
             # Intercept for Steering Vectors
             if self.config.apply_vector_at_layer_idx is not None and layer == self.config.apply_vector_at_layer_idx:
                 x = self.apply_vector_to_layer_output(x)

--- a/train.py
+++ b/train.py
@@ -295,6 +295,7 @@ def parse_args():
         "consmax_quan",
         "polymax",
         "relumax",
+        "sigmoidmax",
         "vpolymax",
         "exppolymax",
         "strongermax",
@@ -333,6 +334,9 @@ def parse_args():
 
     ### ReLUMax Options
     model_group.add_argument("--relumax_divisor", type=float, default=256.0)
+
+    ### SimgoidMax Options
+    model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)
 
     ### SigSoftmax Options
     model_group.add_argument('--sigsoftmax_use_euler_base', default=True, action=argparse.BooleanOptionalAction)

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -478,6 +478,25 @@ class SigSoftmax(nn.Module):
 
         return numerator / denominator
 
+class SigmoidMax(nn.Module):
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.sigmoid = nn.Sigmoid()
+        self.sigmoidmax_divisor = config.sigmoidmax_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+
+    def forward(self, x):
+
+        result = self.sigmoid(x) / self.sigmoidmax_divisor
+
+        # divide by sequence length
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
 class ReLUMax(nn.Module):
     def __init__(self, config, dim=-1):
         super().__init__()
@@ -553,6 +572,7 @@ softmax_dictionary = {
     "strongermax": Strongermax,
     "sigsoftmax": SigSoftmax,
     "relumax": ReLUMax,
+    "sigmoidmax": SigmoidMax,
     "softplus": Softplus,
     "squareplus": Squareplus,
 }


### PR DESCRIPTION
This will allow not setting the abs pos embedding table if one wants to instead finetune Rotary, functional embeddings, or other alternatives which allow for better context length extensions.

To be merged in after PR #262