### PR TITLE
Add gptconf defaults and manual ability to turn off flash attention

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -39,7 +39,7 @@ class GPTConfig:
     export_scale_matrices_each_eval: bool = False
 
     dropout: float = 0.0
-    window_size: int = 128
+    window_size: int = None
     gate: bool = False
     use_moe: bool = False
     moe_layer_freq: int = 2
@@ -57,6 +57,9 @@ class GPTConfig:
     ## Gradient Checkpointing - More memory efficient (can do long contexts), but is slower
     use_gradient_checkpointing: bool = False
     recompute_backward_pass: bool = False
+
+    ## Flash attention
+    disable_flash_attention: bool = False
 
     # MLP Options
     use_parallel_mlp: bool = False
@@ -162,7 +165,7 @@ class GPTConfig:
     fire_outermost_sigma: bool = False
 
     # Structuring Options, remember to compile the model
-    use_post_ln: bool = True
+    use_post_ln: bool = False
 
     # Layernorm Alternatives and Options
     norm_variant_attn: str = "rmsnorm"

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -128,8 +128,11 @@ class GPTConfig:
     ## Softplus options
     softplus_divisor: float = 256.0
 
-    ## Softplus options
+    ## ReLUMax options
     relumax_divisor: float = 256.0
+
+    ## SigmoidMax options
+    sigmoidmax_divisor: float = 256.0
 
     ## Squareplus options
     squareplus_divisor: float = 256.0

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -131,6 +131,9 @@ class GPTConfig:
     ## ReLUMax options
     relumax_divisor: float = 256.0
 
+    ## ReLUMax options
+    relu2max_divisor: float = 256.0
+
     ## SigmoidMax options
     sigmoidmax_divisor: float = 256.0
 

--- a/model.py
+++ b/model.py
@@ -890,6 +890,10 @@ class GPT(nn.Module):
                     if key == "lm_head.weight":
                         continue
 
+                if not config.use_abs_pos_embeddings:
+                    if key == "transformer.wpe.weight":
+                        continue
+
                 assert sd_hf[key].shape == sd[key].shape
                 with torch.no_grad():
                     print(key)

--- a/model.py
+++ b/model.py
@@ -777,10 +777,6 @@ class GPT(nn.Module):
             else:
                 x = block(x)
 
-            # if layer == 6:
-                # select nn.Linear of dimension 1x embedding dimension
-                #x += nn.Linear
-
             # Intercept for Steering Vectors
             if self.config.apply_vector_at_layer_idx is not None and layer == self.config.apply_vector_at_layer_idx:
                 x = self.apply_vector_to_layer_output(x)

--- a/model.py
+++ b/model.py
@@ -777,6 +777,10 @@ class GPT(nn.Module):
             else:
                 x = block(x)
 
+            # if layer == 6:
+                # select nn.Linear of dimension 1x embedding dimension
+                #x += nn.Linear
+
             # Intercept for Steering Vectors
             if self.config.apply_vector_at_layer_idx is not None and layer == self.config.apply_vector_at_layer_idx:
                 x = self.apply_vector_to_layer_output(x)

--- a/softmax_sweep.py
+++ b/softmax_sweep.py
@@ -82,8 +82,9 @@ for variant in softmax_variants:
             # model init
             gptconf = GPTConfig(
                 block_size = block_size, # how far back does the model look? i.e. context size
-                n_layer = 6, n_head = 12, n_embd = 768, # size of the model
+                n_layer = 3, n_head = 12, n_embd = 768, # size of the model
                 softmax_variant_attn = variant,
+                disable_flash_attention = True,
                 strongermax_use_xmax = True,
                 strongermax_sum_to_1 = True,
                 dropout = 0, # for determinism
@@ -176,7 +177,7 @@ for variant in softmax_variants:
     for block_size in block_sizes:
         ln1_ln2_row.append(f"{ln1_ln2_timing_results[variant][block_size]:.4f}")
         forward_pass_row.append(f"{forward_pass_timing_results[variant][block_size]:.4f}")
-    
+
     ln1_ln2_table.add_row(*ln1_ln2_row)
     forward_pass_table.add_row(*forward_pass_row)
 

--- a/train.py
+++ b/train.py
@@ -300,6 +300,7 @@ def parse_args():
         "consmax_quan",
         "polymax",
         "relumax",
+        "relu2max",
         "sigmoidmax",
         "vpolymax",
         "exppolymax",
@@ -339,6 +340,9 @@ def parse_args():
 
     ### ReLUMax Options
     model_group.add_argument("--relumax_divisor", type=float, default=256.0)
+
+    ### ReLU2Max Options
+    model_group.add_argument("--relu2max_divisor", type=float, default=256.0)
 
     ### SimgoidMax Options
     model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)

--- a/train.py
+++ b/train.py
@@ -317,6 +317,7 @@ def parse_args():
     ## Selection of softmax variation for attention and output layers
     model_group.add_argument("--softmax_variant_attn", type=str, default="softmax", choices=softmax_variations)
     model_group.add_argument("--softmax_variant_output", type=str, default="softmax", choices=softmax_variations)
+    model_group.add_argument("--disable_flash_attention", default=False, action=argparse.BooleanOptionalAction, help="manual setting to disable flash attention")
 
     ## Custom Softmax Variation Options
     ### ConSmax and SaturatingConSmax Options

--- a/train.py
+++ b/train.py
@@ -747,11 +747,16 @@ class Trainer:
         dataset = None
         data = None
         if self.args.dataset_list:
-            # If multi-dataset sampling is enabled, randomly pick a dataset
+            # If multi-dataset sampling is enabled, pick a dataset using sampling probabilities
             if target_dataset:
                 dataset = target_dataset
             else:
-                dataset = np.random.choice(self.args.dataset_list)
+                if self.args.dataset_sampling_probs:
+                    # Sample dataset based on probabilities
+                    dataset = np.random.choice(self.args.dataset_list, p=self.args.dataset_sampling_probs)
+                else:
+                    # Default to uniform sampling if probabilities are not provided
+                    dataset = np.random.choice(self.args.dataset_list)
             data = self.train_data_dict[dataset] if split == 'train' else self.val_data_dict[dataset]
         else:
             # Else use the 'dataset' arg by default for backwards compatibility

--- a/train.py
+++ b/train.py
@@ -295,6 +295,7 @@ def parse_args():
         "consmax_quan",
         "polymax",
         "relumax",
+        "sigmoidmax",
         "vpolymax",
         "exppolymax",
         "strongermax",
@@ -333,6 +334,9 @@ def parse_args():
 
     ### ReLUMax Options
     model_group.add_argument("--relumax_divisor", type=float, default=256.0)
+
+    ### SimgoidMax Options
+    model_group.add_argument("--sigmoidmax_divisor", type=float, default=256.0)
 
     ### SigSoftmax Options
     model_group.add_argument('--sigsoftmax_use_euler_base', default=True, action=argparse.BooleanOptionalAction)

--- a/train.py
+++ b/train.py
@@ -153,6 +153,7 @@ def parse_args():
             "mish",
             "prelu",
             "relu6",
+            "relu",
             "rrelu",
             "selu",
             "sigmoid",

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -516,6 +516,24 @@ class ReLUMax(nn.Module):
 
         return result
 
+class ReLU2Max(nn.Module):
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.relu2max_divisor = config.relu2max_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+
+    def forward(self, x):
+
+        result = torch.relu(x) ** 2 / self.relu2max_divisor
+
+        # divide by sequence length
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
 class Softplus(nn.Module):
     """ Softmax variant based on arxiv 1805.10829 with added handles for base """
     def __init__(self, config, dim=-1):
@@ -572,6 +590,7 @@ softmax_dictionary = {
     "strongermax": Strongermax,
     "sigsoftmax": SigSoftmax,
     "relumax": ReLUMax,
+    "relu2max": ReLU2Max,
     "sigmoidmax": SigmoidMax,
     "softplus": Softplus,
     "squareplus": Squareplus,

--- a/variations/softmax_variations.py
+++ b/variations/softmax_variations.py
@@ -478,6 +478,25 @@ class SigSoftmax(nn.Module):
 
         return numerator / denominator
 
+class SigmoidMax(nn.Module):
+    def __init__(self, config, dim=-1):
+        super().__init__()
+        self.dim = dim
+        self.sigmoid = nn.Sigmoid()
+        self.sigmoidmax_divisor = config.sigmoidmax_divisor
+        self.div_by_seq_len = config.div_by_seq_len
+
+    def forward(self, x):
+
+        result = self.sigmoid(x) / self.sigmoidmax_divisor
+
+        # divide by sequence length
+        if self.div_by_seq_len:
+            seq_len = x.shape[self.dim]
+            result = result / seq_len
+
+        return result
+
 class ReLUMax(nn.Module):
     def __init__(self, config, dim=-1):
         super().__init__()
@@ -553,6 +572,7 @@ softmax_dictionary = {
     "strongermax": Strongermax,
     "sigsoftmax": SigSoftmax,
     "relumax": ReLUMax,
+    "sigmoidmax": SigmoidMax,
     "softplus": Softplus,
     "squareplus": Squareplus,
 }


### PR DESCRIPTION
There previously was no way to turn off flash attention while using softmax, this allows that capability (and is normally off).

Also updated the gptconf defaults, which is important so that our benchmarking software will not by default use windowed attention or postln.