### PR TITLE
Add FIReLU

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -137,6 +137,7 @@ class GPTConfig:
     # Positional Embeddings Variations
     use_abs_pos_embeddings: bool = True # Note: one can use this AND rotary embeddings
     use_fire_embeddings: bool = False
+    use_firelu: bool = False
     shared_fire_embeddings: bool = False
     use_rotary_embeddings: bool = False
     sym_rot_num_angles: int = 512

--- a/train.py
+++ b/train.py
@@ -274,6 +274,7 @@ def parse_args():
     model_group.add_argument('--use_abs_pos_embeddings', default=True, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--use_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)
     model_group.add_argument('--shared_fire_embeddings', default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument('--use_firelu', default=False, action=argparse.BooleanOptionalAction, help="bypasses softmax attention, use fire + relu hybrid in causal attention block.")
 
     ## Positional Embedding Weight Initialization Options
     model_group.add_argument( "--embedding_mean_init", type=float, default=0.0)


### PR DESCRIPTION
Adds an option to fuse FIRE operation with the ReLU operation.

If activated, this option bypasses the softmax_variant_attn, instead using FIRE to perform a relumax operation with relumax divisor of 1.