### PR TITLE
Remove torch from requirements_cpu

### DIFF
--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -7,7 +7,6 @@ rich==13.9.2
 scipy==1.14.1
 seaborn==0.13.2
 tiktoken==0.7.0
-torch==2.2.0
 torchinfo==1.8.0
 transformers==4.44.2
 wandb==0.18.3


### PR DESCRIPTION
If installing from requirements_cpu appears to default to gpu instead of cpu.