### PR TITLE
RMSNorm Recompute

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -212,6 +212,11 @@ class GPTConfig:
     quantize_wpe_method: str = "affine_quant"
     quantize_wpe_bits: int = 8
 
+    # RMSNorm Recompute Quantizations
+    quantize_rmsnorm_recompute: bool = False
+    quantize_rmsnorm_recompute_method: str = "affine_quant"
+    quantize_rmsnorm_recompute_bits: int = 8
+
     ## Activation Quantizations
     activations_quant_method: str = "affine_quant"
     quantize_attn_act: bool = False

--- a/model.py
+++ b/model.py
@@ -33,7 +33,7 @@ from variations.position_encoding_variations import QuantizedEmbedding, RotaryEm
 from variations.activation_variations import activation_dictionary
 from variations.linear_variations import linear_dictionary
 from variations.router_variations import router_dictionary
-from quantization.quantize import quantize_dictionary, dequantize, fake_quantize_act
+from quantization.quantize import quantize_dictionary, dequantize, fake_quantize_act, create_activation_buffers
 
 def create_shared_param_group(layer_type, config):
 
@@ -99,12 +99,6 @@ def set_variant(variant, default_variant):
     if not variant:
         return default_variant
     return variant
-
-def create_activation_buffers(obj, arg):
-    arg_str = arg.split("quantize_")[1]
-    obj.register_buffer(arg_str, None)
-    obj.register_buffer(f"{arg_str}_scale", None)
-    obj.register_buffer(f"{arg_str}_zero_point", None)
 
 class CausalSelfAttention(nn.Module):
     def __init__(self, config, fire_pos_enc=None):

--- a/train.py
+++ b/train.py
@@ -163,8 +163,8 @@ def parse_args():
     model_group.add_argument('--shared_attn_sym', default=False, action=argparse.BooleanOptionalAction, help="symmetrical attention sharing")
 
     # NORM VARIATIONS
-    model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "layernorm"])
-    model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "layernorm"])
+    model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "rmsnorm_recompute", "layernorm"])
+    model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "rmsnorm_recompute", "layernorm"])
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
     model_group.add_argument("--prmsnorm_pct", default=0.0625, type=float, help="percentage (1 being 100 percent) of first entries used for partial rms" )
     model_group.add_argument("--krmsnorm_num", default=10, type=int, help="max number of first entries for partial rms" )

--- a/train.py
+++ b/train.py
@@ -164,7 +164,7 @@ def parse_args():
 
     # NORM VARIATIONS
     model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "rmsnorm_recompute", "layernorm"])
-    model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "rmsnorm_recompute", "layernorm"])
+    model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "layernorm"])
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
     model_group.add_argument("--prmsnorm_pct", default=0.0625, type=float, help="percentage (1 being 100 percent) of first entries used for partial rms" )
     model_group.add_argument("--krmsnorm_num", default=10, type=int, help="max number of first entries for partial rms" )
@@ -224,6 +224,11 @@ def parse_args():
     model_group.add_argument("--quantize_wpe", default=None, action=argparse.BooleanOptionalAction, help="Whether the word position embedding is quantized")
     model_group.add_argument("--quantize_wpe_method", type=str, default="affine_quant", choices=quant_methods, help="function used for position embedding quantization")
     model_group.add_argument("--quantize_wpe_bits", type=int, default=8, help="number of bits for position embedding quantization")
+
+    ## RMSNorm Recompute
+    model_group.add_argument("--quantize_rmsnorm_recompute", default=None, action=argparse.BooleanOptionalAction, help="Whether to quantize RMSNorm recompute: dequant(quant(x*W) * 1/RMS)")
+    model_group.add_argument("--quantize_rmsnorm_recompute_method", type=str, default="affine_quant", choices=quant_methods, help="function used for RMSNorm recompute quantization")
+    model_group.add_argument("--quantize_rmsnorm_recompute_bits", type=int, default=8, help="number of bits for RMSNorm recompute quantization")
 
     ## Activations
     model_group.add_argument("--activations_quant_method", type=str, default="affine_quant", choices=quant_methods, help="function used for quantization of activations")


### PR DESCRIPTION
In order to fully emulate hardware, I am adding RMSNorm recompute, which moves the division of RMS until after multiplying by W. This means that for pre-ln, the division happens after the Q, K, and V linears for attention and after the up linear for the MLP.

I also added recompute quantization, as per https://drive.google.com/drive/u/1/folders/1tOjBEBoXytUgU7R95aqWI6deCwyPAWjl