### PR TITLE
Refactor non ipa language targeted words to use [[[[[word]]]]]

### DIFF
--- a/data/glot_cc_ko/count_bracketed_words.py
+++ b/data/glot_cc_ko/count_bracketed_words.py
@@ -1,0 +1,31 @@
+import re
+from collections import Counter
+import argparse
+
+def find_bracketed_words(filename="output.txt"):
+    # Regular expression to match words within [[[[[ ]]]]] brackets
+    pattern = r"\[\[\[\[\[\s*(\w+)\s*\]\]\]\]\]"
+
+    # Read the file content
+    with open(filename, 'r') as file:
+        content = file.read()
+
+    # Find all matches in the file
+    words = re.findall(pattern, content)
+
+    # Count the frequency of each word
+    word_count = Counter(words)
+
+    # Print each word and its frequency
+    for word, count in word_count.items():
+        print(f"{word}: {count}")
+
+if __name__ == "__main__":
+    # Setting up argument parser
+    parser = argparse.ArgumentParser(description="Count frequency of words in [[[[[ ]]]]] brackets.")
+    parser.add_argument("--file", type=str, default="output.txt", help="The file to parse (default: output.txt)")
+    args = parser.parse_args()
+
+    # Run the function
+    find_bracketed_words(args.file)
+

--- a/data/template/utils/ko_en_to_ipa.py
+++ b/data/template/utils/ko_en_to_ipa.py
@@ -7,40 +7,6 @@ import re
 # English number conversion engine
 inflect_engine = inflect.engine()
 
-# Korean number dictionary
-korean_numbers = {
-    0: "영",
-    1: "일",
-    2: "이",
-    3: "삼",
-    4: "사",
-    5: "오",
-    6: "육",
-    7: "칠",
-    8: "팔",
-    9: "구",
-    10: "십"
-}
-
-def number_to_korean(num):
-    """Convert numbers to Korean words."""
-    if num <= 10:
-        return korean_numbers[num]
-    else:
-        result = []
-        if num >= 1000:
-            result.append(korean_numbers[num // 1000] + "천")
-            num %= 1000
-        if num >= 100:
-            result.append(korean_numbers[num // 100] + "백")
-            num %= 100
-        if num >= 10:
-            result.append(korean_numbers[num // 10] + "십")
-            num %= 10
-        if num > 0:
-            result.append(korean_numbers[num])
-        return "".join(result)
-
 def transcribe_english(sentence):
     """Transcribe an English sentence to phonemes using espeak-ng."""
     try:
@@ -58,7 +24,7 @@ def transcribe_korean(sentence):
     okt = Okt()
     tokens = okt.morphs(sentence)
     tokenized_sentence = ' '.join(tokens)
-    
+
     try:
         result = subprocess.run(
             ["espeak-ng", "-q", "-v", "ko", "--ipa", tokenized_sentence],
@@ -72,12 +38,11 @@ def transcribe_korean(sentence):
 def handle_mixed_language(word):
     """Handle a word with potential Korean, English, or number content."""
     if word.isdigit():  # Detect numbers
-        number_in_korean = number_to_korean(int(word))
-        return transcribe_korean(number_in_korean)
+        return word
     elif any('가' <= char <= '힣' for char in word):  # Detect Korean
         return transcribe_korean(word)
-    else:  # English word
-        return transcribe_english(word)
+    else:  # Non Korean Word
+        return "[[[[[" + word + "]]]]]"
 
 def transcribe_multilingual(sentences, output_file):
     """Transcribe multilingual sentences (English and Korean, with numbers) and save to a file."""


### PR DESCRIPTION
Due to limitations of espeak, will not be able to get all words into the target language, thinking we might want to go ahead with just surrounding the words by brackets.

This will allow us to either prune these lines (one line per transcription), or see if there is a pattern we can use to target these for ipa transcription (e.g. if Hanzi or English instead of the Korean -> IPA target, could try adding more manual Hanzi -> Korean IPA transcription).

