### PR TITLE
Got rid of prev_run_ckpt from config name

### DIFF
--- a/.github/workflows/cpu-test-finetuning.yml
+++ b/.github/workflows/cpu-test-finetuning.yml
@@ -1,0 +1,29 @@
+name: Install Then Test Finetuning With prev_run
+on: [push, pull_request]
+jobs:
+  Install-And-Test-Quantization:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "Currently on ${{ github.ref }} branch"
+      - name: ls of directory
+        run: |
+          ls ${{ github.workspace }}
+      - name: Install CPU Dependencies
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          python3 -m pip install numpy transformers datasets tiktoken wandb tqdm tensorboard
+          python3 -m pip install -r requirements_cpu.txt
+          python3 -m pip install ml_dtypes
+      - name: Test finetuning
+        run: |
+          source venv/bin/activate
+          python3 data/shakespeare_char/prepare.py
+          cd tests
+          source test_finetuning_cpu.sh
+

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -94,9 +94,9 @@ def generate_combinations(config):
 
 def format_config_name(config, config_basename, prefix, add_names):
     if add_names:
-        config_items = [f"{k}_{v}" for k, v in config.items()]
+        config_items = [f"{k}_{v}" for k, v in config.items() if k != 'prev_run_ckpt']
     else:
-        config_items = [f"{v}" for _, v in config.items()]
+        config_items = [f"{v}" for k, v in config.items() if k != 'prev_run_ckpt']
 
     return f"{prefix}{config_basename}-{'-'.join(config_items)}"
 

--- a/tests/test_finetuning_cpu.sh
+++ b/tests/test_finetuning_cpu.sh
@@ -37,7 +37,7 @@ python3 train.py \
   --softmax_variant_attn softmax \
   --tensorboard_run_name "$run_name" \
   --block_size "$block_size" \
-  --bias true \
+  --bias \
   --out_dir "${output_dir}"
 
 python3 train.py \
@@ -56,7 +56,7 @@ python3 train.py \
   --softmax_variant_attn relumax \
   --tensorboard_run_name "$run_name" \
   --block_size "$block_size" \
-  --bias true \
+  --bias \
   --out_dir "${output_dir2}"
 
 sleep 3

--- a/tests/test_finetuning_cpu.sh
+++ b/tests/test_finetuning_cpu.sh
@@ -34,7 +34,7 @@ python3 train.py \
   --log_interval 10 \
   --device cpu \
   --dataset "$dataset" \
-  --softmax_variant_attn softmax \
+  --softmax_variant_attn strongermax \
   --tensorboard_run_name "$run_name" \
   --block_size "$block_size" \
   --bias \

--- a/tests/test_finetuning_cpu.sh
+++ b/tests/test_finetuning_cpu.sh
@@ -1,0 +1,60 @@
+#/bin/bash
+
+# head to repo root
+cd ../
+
+dataset="shakespeare_char"
+python3 "data/${dataset}/prepare.py"
+
+n_layer="2"
+n_head="2"
+n_kv_group="2"
+n_embd="60"
+max_iters="50"
+block_size="32"
+eval_iters="50"
+eval_interval="50"
+timestamp="$(date +%F_%T)"
+notes="test_finetuning_using_init-from_prev-ckpt"
+run_name="${dataset}_finetuning_${max_iters}_${block_size}_${n_layer}_${n_head}_${n_embd}_${notes}"
+output_dir="results/${timestamp}_${notes}_finetuning"
+output_dir2="results/${timestamp}_${notes}_finetuning_relu"
+if [ ! -d "${output_dir}" ]; then
+  mkdir -p "${output_dir}"
+fi
+
+python3 train.py \
+  --max_iters "$max_iters" \
+  --n_layer "$n_layer" \
+  --n_head "$n_head" \
+  --n_kv_group "$n_kv_group" \
+  --n_embd "$n_embd" \
+  --eval_iters "$eval_iters" \
+  --eval_interval "$eval_interval" \
+  --log_interval 10 \
+  --device cpu \
+  --dataset "$dataset" \
+  --softmax_variant_attn softmax \
+  --tensorboard_run_name "$run_name" \
+  --block_size "$block_size" \
+  --out_dir "${output_dir}"
+
+python3 train.py \
+  --max_iters "$max_iters" \
+  --init_from prev_run \
+  --prev_run_ckpt "${output_dir}" \
+  --n_layer "$n_layer" \
+  --n_head "$n_head" \
+  --n_kv_group "$n_kv_group" \
+  --n_embd "$n_embd" \
+  --eval_iters "$eval_iters" \
+  --eval_interval "$eval_interval" \
+  --log_interval 10 \
+  --device cpu \
+  --dataset "$dataset" \
+  --softmax_variant_attn relumax \
+  --tensorboard_run_name "$run_name" \
+  --block_size "$block_size" \
+  --out_dir "${output_dir2}"
+
+sleep 3

--- a/tests/test_finetuning_cpu.sh
+++ b/tests/test_finetuning_cpu.sh
@@ -37,6 +37,7 @@ python3 train.py \
   --softmax_variant_attn softmax \
   --tensorboard_run_name "$run_name" \
   --block_size "$block_size" \
+  --bias true \
   --out_dir "${output_dir}"
 
 python3 train.py \
@@ -55,6 +56,7 @@ python3 train.py \
   --softmax_variant_attn relumax \
   --tensorboard_run_name "$run_name" \
   --block_size "$block_size" \
+  --bias true \
   --out_dir "${output_dir2}"
 
 sleep 3

--- a/train.py
+++ b/train.py
@@ -81,6 +81,7 @@ def parse_args():
     training_group.add_argument('--gpt2_type', default='gpt2', type=str)
     training_group.add_argument('--prev_run_ckpt', default='', type=str)
     training_group.add_argument('--csv_ckpt_dir', default='', type=str)
+    training_group.add_argument('--init_from_ckpt', default='ckpt.pt', type=str, help="if save_major_ckpt_interval was set, can use to init from specific ckpts")
 
     # Data args
     training_group.add_argument('--dataset', default='shakespeare_char', type=str)
@@ -615,11 +616,11 @@ class Trainer:
             self.best_val_loss = 1e9 # really big number
         elif self.args.init_from == 'resume' or self.args.init_from == 'prev_run':
             if self.args.init_from == 'resume':
-                ckpt_path = os.path.join(self.args.out_dir, 'ckpt.pt')
+                ckpt_path = os.path.join(self.args.out_dir, self.args.init_from_ckpt)
                 checkpoint = torch.load(ckpt_path, map_location=self.device)
                 self.iter_num = checkpoint['iter_num']
             else:
-                ckpt_path = os.path.join(self.args.prev_run_ckpt, 'ckpt.pt')
+                ckpt_path = os.path.join(self.args.prev_run_ckpt, self.args.init_from_ckpt)
                 checkpoint = torch.load(ckpt_path, map_location=self.device)
                 self.iter_num = 0
 


### PR DESCRIPTION
"init_from": ["prev_run"],
 "prev_run_ckpt": ["fire/fire"]

Using init_from prev_run should work now and create a csv_log file. Fixes the issue of the config name to be too long by removing the prev_run_ckpt.

Before: 
![image](https://github.com/user-attachments/assets/7a2ecb5e-b2ec-4515-8a7c-b608540dafd9)

After (creates the csv_log and output directories):
![image](https://github.com/user-attachments/assets/a6a8ecaf-4aae-405b-b325-9ea5c2b3ad5b)

Also, added the ability to load from an intermediate ckpt. 
Example:
![image](https://github.com/user-attachments/assets/707401cb-f367-4f6c-83c5-83fdece54871)