### PR TITLE
update datasets for multidataset training

### DIFF
--- a/data/commonvoice_ja/get_dataset.sh
+++ b/data/commonvoice_ja/get_dataset.sh
@@ -1,0 +1,63 @@
+# !/bin/bash
+
+# Set strict error handling
+set -euo pipefail
+
+# Install python dependencies for Hugging face
+pip install -U "huggingface_hub[cli]"
+
+# Authentication with Hugging Face
+# Replace with your hugging face tokens
+##### You can find and create your own tokens here: https://huggingface.co/settings/tokens ######
+##### "Token Type" of "Read" is recommended. ########
+HF_TOKEN=""
+
+# Authenticate with hugging face
+echo "Authenticating with Hugging Face..."
+huggingface-cli login --token "${HF_TOKEN}"
+
+# Get current script directory
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+url="https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0"
+out_dir="transcription"
+
+if [[ ! -d "${out_dir}" ]]; then
+  mkdir -p "${out_dir}"
+fi
+
+# Download transcription files under "transcription" directory.
+pushd "${out_dir}"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "dev.tsv" "${url}/resolve/main/transcript/ja/dev.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "invalidated.tsv" "${url}/resolve/main/transcript/ja/validated.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "other.tsv" "${url}/resolve/main/transcript/ja/other.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "test.tsv" "${url}/resolve/main/transcript/ja/test.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "train.tsv" "${url}/resolve/main/transcript/ja/train.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "validated.tsv" "${url}/resolve/main/transcript/ja/validated.tsv?download=true"
+
+echo "transcripts downloaded and saved to transcription."
+popd
+
+# Run program to convert tsv into json format.
+output_file="ja_transcription.json"
+for tsvfile in "$out_dir"/*.tsv; do
+    # Check if the .tsv file exists (handles the case where no .tsv files are present)
+    if [ -f "$tsvfile" ]; then
+        echo "Processing $tsvfile..."
+        # Get the filename without the extension for output filename
+        filename=$(basename "${tsvfile%.tsv}")
+        python3 utils/tsv_to_json_cv.py "$tsvfile" "$output_file"
+    fi
+done
+
+echo "All .tsv files have been processed."
+
+# Run program to convert sentences into IPA format.
+output_ipa="ja_ipa.txt"
+echo "Converting sentences to IPA..."
+python3 utils/ja2ipa.py "$output_file" "$output_ipa"
+
+echo "IPA conversion finished."
+
+# Tokenization step to create train.bin and val.bin files.
+python3 prepare.py -t "$output_ipa" --method char

--- a/data/commonvoice_ja/prepare.py
+++ b/data/commonvoice_ja/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/commonvoice_ja/utils
+++ b/data/commonvoice_ja/utils
@@ -1,0 +1,1 @@
+../template/utils

--- a/data/commonvoice_ko/get_dataset.sh
+++ b/data/commonvoice_ko/get_dataset.sh
@@ -1,0 +1,63 @@
+# !/bin/bash
+
+# Set strict error handling
+set -euo pipefail
+
+# Install python dependencies for Hugging face
+pip install -U "huggingface_hub[cli]"
+
+# Authentication with Hugging Face
+# Replace with your hugging face tokens
+##### You can find and create your own tokens here: https://huggingface.co/settings/tokens ######
+##### "Token Type" of "Read" is recommended. ########
+HF_TOKEN=""
+
+# Authenticate with hugging face
+echo "Authenticating with Hugging Face..."
+huggingface-cli login --token "${HF_TOKEN}"
+
+# Get current script directory
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+url="https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0"
+out_dir="transcription"
+
+if [[ ! -d "${out_dir}" ]]; then
+  mkdir -p "${out_dir}"
+fi
+
+# Download transcription files under "transcription" directory.
+pushd "${out_dir}"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "dev.tsv" "${url}/resolve/main/transcript/ko/dev.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "invalidated.tsv" "${url}/resolve/main/transcript/ko/validated.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "other.tsv" "${url}/resolve/main/transcript/ko/other.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "test.tsv" "${url}/resolve/main/transcript/ko/test.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "train.tsv" "${url}/resolve/main/transcript/ko/train.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "validated.tsv" "${url}/resolve/main/transcript/ko/validated.tsv?download=true"
+
+echo "transcripts downloaded and saved to transcription."
+popd
+
+# Run program to convert tsv into json format.
+output_file="ko_transcription.json"
+for tsvfile in "$out_dir"/*.tsv; do
+    # Check if the .tsv file exists (handles the case where no .tsv files are present)
+    if [ -f "$tsvfile" ]; then
+        echo "Processing $tsvfile..."
+        # Get the filename without the extension for output filename
+        filename=$(basename "${tsvfile%.tsv}")
+        python3 utils/tsv_to_json_cv.py "$tsvfile" "$output_file"
+    fi
+done
+
+echo "All .tsv files have been processed."
+
+# Run program to convert sentences into IPA format.
+output_ipa="ko_ipa.txt"
+echo "Converting sentences to IPA..."
+python3 utils/ko_en_to_ipa.py "$output_file" "$output_ipa"
+
+echo "IPA conversion finished."
+
+# Tokenization step to create train.bin and val.bin files.
+python3 prepare.py -t "$output_ipa" --method char

--- a/data/commonvoice_ko/prepare.py
+++ b/data/commonvoice_ko/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/commonvoice_ko/utils
+++ b/data/commonvoice_ko/utils
@@ -1,0 +1,1 @@
+../template/utils

--- a/data/commonvoice_zh/get_dataset.sh
+++ b/data/commonvoice_zh/get_dataset.sh
@@ -1,0 +1,65 @@
+# !/bin/bash
+
+# Set strict error handling
+set -euo pipefail
+
+# Install python dependencies for Hugging face
+pip install -U "huggingface_hub[cli]"
+# Install necessary dependencies for zh->IPA conversion
+pip install dragonmapper
+pip install jieba
+
+# Authentication with Hugging Face
+# Replace with your hugging face tokens
+##### You can find and create your own tokens here: https://huggingface.co/settings/tokens ######
+##### "Token Type" of "Read" is recommended. ########
+HF_TOKEN=""
+
+# Authenticate with hugging face
+echo "Authenticating with Hugging Face..."
+huggingface-cli login --token "${HF_TOKEN}"
+
+# Get current script directory
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+url="https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0"
+out_dir="transcription"
+
+if [[ ! -d "${out_dir}" ]]; then
+  mkdir -p "${out_dir}"
+fi
+
+# Download transcription files under "transcription" directory.
+pushd "${out_dir}"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "dev.tsv" "${url}/resolve/main/transcript/zh-CN/dev.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "other.tsv" "${url}/resolve/main/transcript/zh-CN/other.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "test.tsv" "${url}/resolve/main/transcript/zh-CN/test.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "train.tsv" "${url}/resolve/main/transcript/zh-CN/train.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "validated.tsv" "${url}/resolve/main/transcript/zh-CN/validated.tsv?download=true"
+
+echo "transcripts downloaded and saved to transcription."
+popd
+
+# Run program to convert tsv into json format.
+output_file="zh_transcription.json"
+for tsvfile in "$out_dir"/*.tsv; do
+    # Check if the .tsv file exists (handles the case where no .tsv files are present)
+    if [ -f "$tsvfile" ]; then
+        echo "Processing $tsvfile..."
+        # Get the filename without the extension for output filename
+        filename=$(basename "${tsvfile%.tsv}")
+        python3 utils/tsv_to_json_cv.py "$tsvfile" "$output_file"
+    fi
+done
+
+echo "All .tsv files have been processed."
+
+# Run program to convert sentences into IPA format.
+output_ipa="zh_ipa.txt"
+echo "Converting sentences to IPA..."
+python3 utils/zh_to_ipa.py "$output_file" "$output_ipa"
+
+echo "IPA conversion finished."
+
+# Tokenization step to create train.bin and val.bin files.
+python3 prepare.py -t "$output_ipa" --method char

--- a/data/commonvoice_zh/prepare.py
+++ b/data/commonvoice_zh/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/commonvoice_zh/utils
+++ b/data/commonvoice_zh/utils
@@ -1,0 +1,1 @@
+../template/utils

--- a/data/prepare.py
+++ b/data/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/template/utils/tsv_to_json_cv.py
+++ b/data/template/utils/tsv_to_json_cv.py
@@ -1,0 +1,36 @@
+import os
+import argparse
+import csv
+import json
+
+def tsv_to_json(input_file, output_file):
+    lists = []
+    with open(input_file, 'r') as file:
+        reader = csv.DictReader(file, delimiter='\t')
+        next(reader) # skip the title row
+        for row in reader:
+            data = {
+                "path": row['path'],
+                "sentence": row['sentence'],
+                "up_votes": row['up_votes'],
+                "down_votes": row['down_votes'],
+                "age": row['age'],
+                "gender": row['gender'],
+                "accents": row['accents'],
+                "variant": row['variant'],
+                "locale": row['locale'],
+                "segment": row['segment']
+            }
+            lists.append(data)
+
+    with open(output_file, 'w') as json_file:
+        json.dump(lists, json_file, indent=4)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Divide a large text file into smaller files.")
+    parser.add_argument("input_file", type=str, help="Path to the input tsv file.")
+    parser.add_argument("output_json", type=str, help="Path to the output json file.")
+
+    args = parser.parse_args()
+    tsv_to_json(args.input_file, args.output_json)

--- a/data/template/utils/zh_to_ipa.py
+++ b/data/template/utils/zh_to_ipa.py
@@ -1,0 +1,60 @@
+import subprocess
+from dragonmapper import hanzi
+import jieba
+import argparse
+import re
+import json
+
+def transcribe_chinese(sentence):
+    """Transcribe a Chinese sentence into its phonemes using dragonmapper."""
+    try:
+        result = hanzi.to_ipa(sentence)
+        return "".join(result)
+    except Exception as e:
+        return f"Error in transcribing Chinese: {str(e)}"
+
+def handle_mixed_language(word):
+    """Handle a word with potential Chinese, Language, or number content."""
+    if word.isdigit():  # Detect numbers but just pass through for now (different in each language)
+        return word
+    elif any(hanzi.is_simplified(char) for char in word):  # Detect Chinese
+        return transcribe_chinese(word)
+    else:  # Non-Chinese Word
+        return "[[[[[" + word + "]]]]]"
+
+def transcribe_multilingual(lists, output_file):
+    """Transcribe multilingual sentences (English and Chinese, with numbers) and save to a file."""
+    with open(output_file, 'w', encoding='utf-8') as f:
+        for item in lists:
+            result = []
+            sentence = item['sentence']
+            # Split sentence using jieba
+            seg_list = jieba.cut(sentence, cut_all=False)
+            seg_sentence = " ".join(seg_list)
+            # Split sentence but keep punctuation (preserve spaces, commas, etc.)
+            words = re.findall(r'\w+|[^\w\s]', seg_sentence, re.UNICODE)
+            for word in words:
+                if re.match(r'\w+', word):  # Only process words (skip punctuation)
+                    result.append(handle_mixed_language(word))
+                else:
+                    result.append(word)  # Preserve punctuation as is
+            transcription_result = " ".join(result)
+            f.write(transcription_result + "\n")
+            print(transcription_result)  # Print to console for reference
+
+def main():
+    parser = argparse.ArgumentParser(description='Transcribe multilingual sentences into IPA phonemes.')
+    parser.add_argument('input_file', type=str, help='Path to the input file containing sentences in json format.')
+    parser.add_argument('output_file', type=str, help='Path to the output file for IPA transcription.')
+
+    args = parser.parse_args()
+
+    # Read input sentences
+    with open(args.input_file, 'r', encoding='utf-8') as f:
+        lists = json.load(f)
+
+    # Transcribe and save to the output file
+    transcribe_multilingual(lists, args.output_file)
+
+if __name__ == '__main__':
+    main()

--- a/data/utils
+++ b/data/utils
@@ -1,0 +1,1 @@
+../template/utils


### PR DESCRIPTION
Dataset and related files added for multidataset training. 
Specifically, 

> ./data/template/utils/zh_to_ipa.py

 is the python file to convert zhongwen into IPA.

> ./data/template/utils/tsv_to_json_cv.py

 is the python file to store data in JSON format instead of tsv.

> ./data/commonvoice_ja, ./data/commonvoice_ko, ./data/commonvoice_zh

 folders created for dataset preprocessing. 

Running `bash get_dataset.sh` can download the corresponding dataset from huggingface, store them in json file, convert and save them in IPA, and do the tokenization to get train.bin and val.bin (Remember to input your huggingface **Access Tokens** before running this file).

**Note:** the get_dataset.sh in commonvoice_ko and commonvoice_ja may return error when running them. For commonvoice_ko, remember to install the necessary packages for IPA conversion before running the file. For commonvoice_ja, the corresponding IPA conversion file might need to make some small changes to be compatible with this preprocessing process.