### PR TITLE
Add hypersphere norm variation

### DIFF
--- a/explorations/hsnorm.json
+++ b/explorations/hsnorm.json
@@ -1,0 +1,35 @@
+
+[
+    {
+      "parameter_groups": [
+          {
+          "norm_variant_attn" : ["rmsnorm"],
+          "norm_variant_output" : ["rmsnorm"],
+          "tensorboard_log_name": ["regular_rmsnorm"]
+          },
+          {
+          "norm_variant_attn" : ["hyperspherenorm"],
+          "norm_variant_output" : ["hyperspherenorm"],
+          "hsnorm_radius": ["5", "10", "15", "20", "25"],
+          "hsnorm_radius_learning": [true, false],
+          "tensorboard_log_name": ["set_radius"]
+          },
+          {
+          "norm_variant_attn" : ["hyperspherenorm"],
+          "norm_variant_output" : ["hyperspherenorm"],
+          "hsnorm_radius_learning": [true, false],
+          "tensorboard_log_name": ["root_embd_dim_radius"]
+          }
+      ],
+      "max_iters": ["3500"],
+      "n_layer": ["6"],
+      "n_kv_group": ["6"],
+      "n_head": ["6"],
+      "n_embd": ["384"],
+      "block_size":["256"],
+      "device": ["cuda"],
+      "dtype": ["float16", "bfloat16", "float32"],
+      "compile": [true]
+    }
+]
+

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -200,6 +200,9 @@ class GPTConfig:
     krmsnorm_enable_gain: bool = True
     krmsnorm_selection_type: str = 'last'
     krmsnorm_recompute_percentage: float = 0.05
+    hsnorm_gain: bool = False
+    hsnorm_radius: float = None
+    hsnorm_radius_learning: float = None
 
     # Activation Alternatives
 

--- a/train_args.py
+++ b/train_args.py
@@ -133,15 +133,34 @@ def parse_args():
     model_group.add_argument('--shared_attn_sym', default=False, action=argparse.BooleanOptionalAction, help="symmetrical attention sharing")
 
     # NORM VARIATIONS
-    model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "layernorm"])
-    model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=["krmsnorm", "prmsnorm", "rmsnorm", "layernorm"])
+    norm_variations = [
+            "krmsnorm",
+            "prmsnorm",
+            "rmsnorm",
+            "layernorm",
+            "hyperspherenorm",
+            ]
+
+    model_group.add_argument("--norm_variant_attn", type=str, default="rmsnorm", choices=norm_variations)
+    model_group.add_argument("--norm_variant_output", type=str, default="rmsnorm", choices=norm_variations)
+
+    ## Layernorm
     model_group.add_argument('--bias', default=False, action=argparse.BooleanOptionalAction, help="only used for layernorm variation option")
+
+    ## PRMSNorm
     model_group.add_argument("--prmsnorm_pct", default=0.0625, type=float, help="percentage (1 being 100 percent) of first entries used for partial rms" )
+
+    ## KRMSNorm
     model_group.add_argument("--krmsnorm_num", default=10, type=int, help="max number of first entries for partial rms" )
     model_group.add_argument("--krmsnorm_quantize_type", type=str, default="none", choices=["int8", "int16", "none"])
     model_group.add_argument('--krmsnorm_enable_gain', default=True, action=argparse.BooleanOptionalAction, help="include gain in kRMSNorm")
     model_group.add_argument("--krmsnorm_selection_type", type=str, default="last", choices=["first", "last", "random"])
     model_group.add_argument("--krmsnorm_recompute_percentage", type=float, default=None, help="percentage needed within the total RMS to not trigger recompute")
+
+    ## HyperSphereNorm
+    model_group.add_argument("--hsnorm_gain", default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument("--hsnorm_radius", type=float, default=None)
+    model_group.add_argument("--hsnorm_radius_learning", default=False, action=argparse.BooleanOptionalAction)
 
     activation_variations = [
             "celu",


### PR DESCRIPTION
This is a slight variation which removes gain and thus performs mapping of the token vector to the surface of a hypersphere.

As to the radius of the hypersphere, optional parameters are added for setting the hypersphere radius directly (defaulting to square root of the embedding dim), also optionally letting it be a learned after initializing.