### PR TITLE
CJK multidataset additions

### DIFF
--- a/data/commonvoice_ja/get_dataset.sh
+++ b/data/commonvoice_ja/get_dataset.sh
@@ -1,7 +1,6 @@
 # !/bin/bash
 
-# Set strict error handling
-set -euo pipefail
+set -xe
 
 # Install python dependencies for Hugging face
 pip install -U "huggingface_hub[cli]"
@@ -10,7 +9,13 @@ pip install -U "huggingface_hub[cli]"
 # Replace with your hugging face tokens
 ##### You can find and create your own tokens here: https://huggingface.co/settings/tokens ######
 ##### "Token Type" of "Read" is recommended. ########
-HF_TOKEN=""
+if [[ -f ~/.cache/huggingface/token && -s ~/.cache/huggingface/token ]]; then
+  export HF_TOKEN=$(cat ~/.cache/huggingface/token)
+else
+  echo "Consider running 'python3 ./utils/save_hf_token.py' to automate finding HF_TOKEN"
+  read -s -p "To continue, please enter your Hugging Face token: " HF_TOKEN
+  echo "" # Add a newline for better readability
+fi
 
 # Authenticate with hugging face
 echo "Authenticating with Hugging Face..."
@@ -28,12 +33,12 @@ fi
 
 # Download transcription files under "transcription" directory.
 pushd "${out_dir}"
-wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "dev.tsv" "${url}/resolve/main/transcript/ja/dev.tsv?download=true"
-wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "invalidated.tsv" "${url}/resolve/main/transcript/ja/validated.tsv?download=true"
-wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "other.tsv" "${url}/resolve/main/transcript/ja/other.tsv?download=true"
-wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "test.tsv" "${url}/resolve/main/transcript/ja/test.tsv?download=true"
-wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "train.tsv" "${url}/resolve/main/transcript/ja/train.tsv?download=true"
-wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "validated.tsv" "${url}/resolve/main/transcript/ja/validated.tsv?download=true"
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "dev.tsv" "${url}/resolve/main/transcript/ja/dev.tsv?download=true" || true
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "invalidated.tsv" "${url}/resolve/main/transcript/ja/validated.tsv?download=true" || true
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "other.tsv" "${url}/resolve/main/transcript/ja/other.tsv?download=true" || true
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "test.tsv" "${url}/resolve/main/transcript/ja/test.tsv?download=true" || true
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "train.tsv" "${url}/resolve/main/transcript/ja/train.tsv?download=true" || true
+wget --header="Authorization: Bearer ${HF_TOKEN}" -nc -O "validated.tsv" "${url}/resolve/main/transcript/ja/validated.tsv?download=true" || true
 
 echo "transcripts downloaded and saved to transcription."
 popd
@@ -46,18 +51,28 @@ for tsvfile in "$out_dir"/*.tsv; do
         echo "Processing $tsvfile..."
         # Get the filename without the extension for output filename
         filename=$(basename "${tsvfile%.tsv}")
-        python3 utils/tsv_to_json_cv.py "$tsvfile" "$output_file"
+        python3 utils/tsv_to_json_cv_pandas.py "$tsvfile" "$output_file"
     fi
 done
 
 echo "All .tsv files have been processed."
 
-# Run program to convert sentences into IPA format.
-output_ipa="ja_ipa.txt"
+# # Run program to convert sentences into IPA format.
+output_json_with_ipa="ja_ipa.json"
 echo "Converting sentences to IPA..."
-python3 utils/ja2ipa.py "$output_file" "$output_ipa"
-
+python3 utils/ja2ipa.py  -j "$output_file" "$output_json_with_ipa"
 echo "IPA conversion finished."
 
+output_ipa_txt="ja_ipa.txt"
+python3 utils/extract_json_values.py "$output_json_with_ipa" "sentence_ipa" "$output_ipa_txt" 
+echo "IPA extraction finished."
+
+#TODO(gkielian): see if we can fix the parsing of rows instead of deleting
+# Remove lines which were not correclty processed (and start with numberic hash)
+wc -l "$output_ipa_txt"
+sed -i "/^[0-9].*/g" "$output_ipa_txt"
+wc -l "$output_ipa_txt"
+
+
 # Tokenization step to create train.bin and val.bin files.
-python3 prepare.py -t "$output_ipa" --method char
+python3 prepare.py -t "$output_ipa_txt" --method char

--- a/data/commonvoice_ko/get_dataset.sh
+++ b/data/commonvoice_ko/get_dataset.sh
@@ -53,9 +53,12 @@ done
 echo "All .tsv files have been processed."
 
 # Run program to convert sentences into IPA format.
-output_ipa="ko_ipa.txt"
 echo "Converting sentences to IPA..."
-python3 utils/ko_en_to_ipa.py "$output_file" "$output_ipa"
+python3 ./utils/ko_en_to_ipa.py "$output_file" --input_json_key "sentence" --output_json_key "phonetic"
+
+output_ipa="ko_ipa.txt"
+echo "export IPA to txt file"
+python3 ./utils/extract_json_values.py "$output_file" "phonetic" "$output_ipa"
 
 echo "IPA conversion finished."
 

--- a/data/prepare.py
+++ b/data/prepare.py
@@ -1,1 +1,0 @@
-../template/prepare.py

--- a/data/template/parallel_embeddings/part_of_speech_zh.py
+++ b/data/template/parallel_embeddings/part_of_speech_zh.py
@@ -1,0 +1,8 @@
+import jieba.posseg as pseg
+
+text = "他今天在北京大学的图书馆里看书，学习非常认真。这本书很有意思，内容包括历史、哲学和科学。"
+
+words = pseg.cut(text)
+
+for word, flag in words:
+    print(f"{word}: {flag}")

--- a/data/template/utils/extract_json_values.py
+++ b/data/template/utils/extract_json_values.py
@@ -1,0 +1,50 @@
+import json
+import argparse
+
+def extract_values_by_key(json_file, key, output_file):
+    """
+    Extracts all values associated with a specific key from a JSON file
+    and writes them to an output text file, each value on a new line.
+
+    Args:
+        json_file: Path to the input JSON file.
+        key: The key to search for in the JSON data.
+        output_file: Path to the output text file.
+    """
+    try:
+        with open(json_file, 'r', encoding='utf-8') as f_in, open(output_file, 'w', encoding='utf-8') as f_out:
+            data = json.load(f_in)
+
+            def extract_values(data, key, f_out):
+                if isinstance(data, dict):
+                    for k, v in data.items():
+                        if k == key:
+                            f_out.write(str(v) + '\n')
+                        else:
+                            extract_values(v, key, f_out)
+                elif isinstance(data, list):
+                    for item in data:
+                        extract_values(item, key, f_out)
+
+            extract_values(data, key, f_out)
+
+    except FileNotFoundError:
+        print(f"Error: Input file '{json_file}' not found.")
+    except json.JSONDecodeError:
+        print(f"Error: Invalid JSON format in '{json_file}'.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract values of a specific key from a JSON file to a text file.")
+    parser.add_argument("json_file", help="Path to the input JSON file.")
+    parser.add_argument("key", help="The key whose values you want to extract.")
+    parser.add_argument("output_file", help="Path to the output text file.")
+
+    args = parser.parse_args()
+
+    extract_values_by_key(args.json_file, args.key, args.output_file)
+    print(f"Values for key '{args.key}' extracted to '{args.output_file}'")
+
+if __name__ == "__main__":
+    main()

--- a/data/template/utils/meta_util.py
+++ b/data/template/utils/meta_util.py
@@ -58,7 +58,21 @@ def create_meta_from_text(text_file, output_path, special_chars={"<ukn>": 0}):
         pickle.dump(meta, f)
     print(f"Meta created from text and saved to {output_path}.")
 
-
+def export_tokens(meta_path, output_path):
+    meta = load_meta(meta_path)
+    with open(output_path, "w") as f:
+        for i in range(meta["vocab_size"]):
+            token = meta["itos"][i]
+            if token == "\n":
+                token = "\\n"
+            elif token == "\t":
+                token = "\\t"
+            elif token == "\r":
+                token = "\\r"
+            # Note: Add more special character handling here as needed
+            f.write(token + "\n")
+    print(f"Tokens exported to {output_path}")
+    
 def main():
     parser = argparse.ArgumentParser(description="Utility for handling token metadata.")
 
@@ -73,6 +87,12 @@ def main():
         nargs=2,
         help="Path to the input text file and the output meta.pkl file for creation.",
     )
+    
+    parser.add_argument(
+        "--export",
+        nargs=2,
+        help="Path to the meta.pkl file and the output text file for exporting tokens.",
+    )
 
     args = parser.parse_args()
 
@@ -82,7 +102,8 @@ def main():
         merge_metas(args.merge[0], args.merge[1], "merged_meta.pkl")
     elif args.create:
         create_meta_from_text(args.create[0], args.create[1])
-
+    elif args.export:
+        export_tokens(args.export[0], args.export[1])
 
 if __name__ == "__main__":
     main()

--- a/data/template/utils/save_hf_token.py
+++ b/data/template/utils/save_hf_token.py
@@ -1,0 +1,7 @@
+from getpass import getpass
+from huggingface_hub import HfFolder
+
+HF_TOKEN = getpass("Enter your Hugging Face token: ")
+
+HfFolder.save_token(HF_TOKEN) 
+print("Token saved successfully!")

--- a/data/template/utils/tokenization_inspection.py
+++ b/data/template/utils/tokenization_inspection.py
@@ -1,0 +1,96 @@
+import argparse
+import collections
+
+def analyze_text(char_file, text_file, num_lines, save_lines):
+    """
+    Analyzes a text file based on a given set of characters.
+
+    Args:
+        char_file (str): Path to the file containing the list of characters.
+        text_file (str): Path to the text file to be analyzed.
+        num_lines (int): Number of lines to display (for option 2).
+        save_lines (str): Path to save the lines with characters (optional).
+    """
+
+    try:
+        with open(char_file, 'r', encoding='utf-8') as f:
+            chars = set(f.read().split())
+    except FileNotFoundError:
+        print(f"Error: Character file not found at {char_file}")
+        return
+
+    try:
+        with open(text_file, 'r', encoding='utf-8') as f:
+            text_content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Text file not found at {text_file}")
+        return
+
+    # 1. CLI Histogram of character occurrences
+    char_counts = collections.Counter(c for c in text_content if c in chars)
+
+    if char_counts:
+        print("\nCharacter Frequency (CLI Histogram):")
+        max_count = max(char_counts.values())
+        for char, count in sorted(char_counts.items()):
+            bar_length = int(40 * count / max_count)  # Scale bar to 40 characters
+            print(f"{char}: {'█' * bar_length} ({count})")
+    else:
+        print("No characters from the character file were found in the text file.")
+
+    # 2. List of lines with characters
+    lines_with_chars = []
+    with open(text_file, 'r', encoding='utf-8') as f:
+        for line_num, line in enumerate(f, 1):
+            if any(c in line for c in chars):
+                lines_with_chars.append(f"Line {line_num}: {line.strip()}")
+
+    if lines_with_chars:
+        print("\nLines containing specified characters:")
+        for line in lines_with_chars[:num_lines]:
+            print(line)
+
+        if save_lines:
+            try:
+                with open(save_lines, 'w', encoding='utf-8') as outfile:
+                    for line in lines_with_chars:
+                        outfile.write(line + '\n')
+                print(f"Lines saved to {save_lines}")
+            except Exception as e:
+                print(f"Error saving lines to file: {e}")
+    else:
+        print("No lines in the text file contain the specified characters.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze a text file based on a set of characters.")
+    parser.add_argument("char_file", help="Path to the file containing the list of characters.")
+    parser.add_argument("text_file", help="Path to the text file to analyze.")
+    args = parser.parse_args()
+
+    while True:
+        print("\nChoose an option:")
+        print("1. Show CLI histogram of character occurrences")
+        print("2. List lines containing characters")
+        print("3. Exit")
+
+        choice = input("Enter your choice (1, 2, or 3): ")
+
+        if choice == '1':
+            analyze_text(args.char_file, args.text_file, 0, None)
+        elif choice == '2':
+            num_lines = input("Enter the number of lines to display (default 10): ")
+            num_lines = int(num_lines) if num_lines.isdigit() else 10
+
+            save_option = input("Save lines to a file? (y/n): ").lower()
+            save_path = None
+            if save_option == 'y':
+                save_path = input("Enter the path to save the file: ")
+
+            analyze_text(args.char_file, args.text_file, num_lines, save_path)
+        elif choice == '3':
+            break
+        else:
+            print("Invalid choice. Please enter 1, 2, or 3.")
+
+if __name__ == "__main__":
+    main()

--- a/data/template/utils/tsv_to_json_cv_pandas.py
+++ b/data/template/utils/tsv_to_json_cv_pandas.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import argparse
+import json
+
+def tsv_to_json_auto_columns(input_file, output_file, delimiter='\t'):
+    """
+    Converts a TSV file to a JSON file, automatically detecting column names.
+
+    Args:
+        input_file (str): Path to the input TSV file.
+        output_file (str): Path to the output JSON file.
+        delimiter (str, optional): Delimiter used in the TSV file. Defaults to '\t' (tab).
+    """
+    try:
+        # Read the TSV file using pandas, automatically detecting header
+        df = pd.read_csv(input_file, sep=delimiter, header='infer')
+
+        # Convert DataFrame to a list of dictionaries (JSON format)
+        data = df.to_dict(orient='records')
+
+        # Write to JSON file with pretty printing
+        with open(output_file, 'w') as f:
+            json.dump(data, f, indent=4)
+
+        print(f"Successfully converted '{input_file}' to '{output_file}'")
+
+    except FileNotFoundError:
+        print(f"Error: Input file '{input_file}' not found.")
+    except pd.errors.ParserError:
+        print(f"Error: Invalid TSV format in '{input_file}'. Check the delimiter and file structure.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert a TSV file to JSON with automatic column name detection.")
+    parser.add_argument("input_file", help="Path to the input TSV file.")
+    parser.add_argument("output_file", help="Path to the output JSON file.")
+    parser.add_argument("--delimiter", default='\t', help="Delimiter used in the TSV (default: tab)")
+
+    args = parser.parse_args()
+
+    tsv_to_json_auto_columns(args.input_file, args.output_file, args.delimiter)

--- a/data/template/utils/zh_to_ipa.py
+++ b/data/template/utils/zh_to_ipa.py
@@ -5,6 +5,7 @@ import argparse
 import re
 import json
 
+
 def transcribe_chinese(sentence):
     """Transcribe a Chinese sentence into its phonemes using dragonmapper."""
     try:
@@ -12,6 +13,7 @@ def transcribe_chinese(sentence):
         return "".join(result)
     except Exception as e:
         return f"Error in transcribing Chinese: {str(e)}"
+
 
 def handle_mixed_language(word):
     """Handle a word with potential Chinese, Language, or number content."""
@@ -22,39 +24,105 @@ def handle_mixed_language(word):
     else:  # Non-Chinese Word
         return "[[[[[" + word + "]]]]]"
 
-def transcribe_multilingual(lists, output_file):
-    """Transcribe multilingual sentences (English and Chinese, with numbers) and save to a file."""
-    with open(output_file, 'w', encoding='utf-8') as f:
-        for item in lists:
-            result = []
-            sentence = item['sentence']
-            # Split sentence using jieba
-            seg_list = jieba.cut(sentence, cut_all=False)
-            seg_sentence = " ".join(seg_list)
-            # Split sentence but keep punctuation (preserve spaces, commas, etc.)
-            words = re.findall(r'\w+|[^\w\s]', seg_sentence, re.UNICODE)
-            for word in words:
-                if re.match(r'\w+', word):  # Only process words (skip punctuation)
-                    result.append(handle_mixed_language(word))
+
+def transcribe_multilingual(data, output_file, json_inplace_update=False, json_input_field="sentence",
+                            json_output_field="sentence_ipa"):
+    """
+    Transcribe multilingual sentences (English and Chinese, with numbers) and save to a file.
+
+    Args:
+        data: The input data (list of dictionaries if JSON, list of strings if plain text).
+        output_file: Path to the output file.
+        json_inplace_update: If True, process JSON input and add IPA to the same JSON.
+        json_input_field: The field in the JSON data to transcribe (default: "sentence").
+        json_output_field: The field to write the IPA transcription to (default: "sentence_ipa").
+    """
+    if json_inplace_update:
+        # In-place update for JSON data
+        for item in data:
+            if json_input_field in item:
+                sentence = item[json_input_field]
+                result = []
+
+                # Split sentence using jieba
+                seg_list = jieba.cut(sentence, cut_all=False)
+                seg_sentence = "".join(seg_list)
+
+                # Split sentence but keep punctuation
+                words = re.findall(r'\w+|[^\w\s]', seg_sentence, re.UNICODE)
+                for word in words:
+                    if re.match(r'\w+', word):  # Only process words
+                        result.append(handle_mixed_language(word))
+                    else:
+                        result.append(word)  # Preserve punctuation
+
+                transcription_result = " ".join(result)
+                item[json_output_field] = transcription_result
+
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)
+            print(f"In-place JSON transcription saved to {output_file}")
+
+    else:
+        # Standard transcription (either JSON or plain text to plain text output)
+        with open(output_file, 'w', encoding='utf-8') as f:
+            for item in data:
+                result = []
+                if isinstance(item, dict):
+                    sentence = item.get(json_input_field, "")
                 else:
-                    result.append(word)  # Preserve punctuation as is
-            transcription_result = " ".join(result)
-            f.write(transcription_result + "\n")
-            print(transcription_result)  # Print to console for reference
+                    sentence = item
+
+                # Split sentence using jieba
+                seg_list = jieba.cut(sentence, cut_all=False)
+                seg_sentence = "".join(seg_list)
+
+                # Split sentence but keep punctuation
+                words = re.findall(r'\w+|[^\w\s]', seg_sentence, re.UNICODE)
+                for word in words:
+                    if re.match(r'\w+', word):  # Only process words
+                        result.append(handle_mixed_language(word))
+                    else:
+                        result.append(word)  # Preserve punctuation
+
+                transcription_result = " ".join(result)
+                f.write(transcription_result + "\n")
+                print(transcription_result)  # Print to console
+
 
 def main():
     parser = argparse.ArgumentParser(description='Transcribe multilingual sentences into IPA phonemes.')
-    parser.add_argument('input_file', type=str, help='Path to the input file containing sentences in json format.')
+    parser.add_argument('input_file', type=str,
+                        help='Path to the input file containing sentences in json format.')
     parser.add_argument('output_file', type=str, help='Path to the output file for IPA transcription.')
+    parser.add_argument('--input_type', type=str, choices=['json', 'text'], default='json',
+                        help='Type of input file: "json" or "text" (default: json)')
+    parser.add_argument("-j", "--json_inplace_update", action="store_true",
+                        help="Process JSON input and add IPA to the same JSON entries")
+    parser.add_argument("--json_input_field", default="sentence",
+                        help="JSON field to read from (default: sentence)")
+    parser.add_argument("--json_output_field", default="sentence_ipa",
+                        help="JSON field to write IPA to (default: sentence_ipa)")
 
     args = parser.parse_args()
 
-    # Read input sentences
-    with open(args.input_file, 'r', encoding='utf-8') as f:
-        lists = json.load(f)
+    try:
+        with open(args.input_file, 'r', encoding='utf-8') as f:
+            if args.input_type == 'json':
+                data = json.load(f)
+            else:
+                data = f.readlines()
 
-    # Transcribe and save to the output file
-    transcribe_multilingual(lists, args.output_file)
+        transcribe_multilingual(data, args.output_file, args.json_inplace_update,
+                                args.json_input_field, args.json_output_field)
+
+    except FileNotFoundError:
+        print(f"Error: Input file '{args.input_file}' not found.")
+    except json.JSONDecodeError:
+        print(f"Error: Invalid JSON format in '{args.input_file}'.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Main changes:

Common File Changes:
- [x] meta_util.py - add argparse setting to export characters from tokenizer
- [x] get_dataset.sh alignment - same keys for each of cjk, also added hftoken handling now to each

ParallelEmbeddings
- [ ] Part of Speech Embeddings
  - [ ] parallel_embeddings/part_of_speech_zh.py - jieba method for part of speech tagging for zhongwen
  - [ ] parallel_embeddings/part_of_speech_ja.py - jieba method for part of speech tagging for japanese
  - [ ] parallel_embeddings/part_of_speech_ko.py - jieba method for part of speech tagging for korean
- [ ] Articulatory Phonetics Embedding Lanes
  - [ ] lanes for each of articulatory locations, for vocalization, liquid, tongue posiiton. 

Word Separation
- [ ] add mecab based word separation (and part of speech mapping) to the above

Looking forward to starting multidataset training soon.