### PR TITLE
Ipa with spaces and part of speech

### DIFF
--- a/data/template/utils/ja2ipa.py
+++ b/data/template/utils/ja2ipa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+# ja2ipa.py
 import argparse
 import json
 import sys
@@ -365,35 +365,33 @@ def hiragana_to_ipa(text: str) -> str:
 
 
 # ========== 2) MeCab Morphological Tokenization ==========
-
-def mecab_spaced_reading(text: str) -> Tuple[Optional[str], Optional[str]]:
+def mecab_spaced_reading(text: str) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
     """
-    Use MeCab for morphological analysis. Return two strings:
-      1) spaced_original: original surface forms joined by spaces (no "は"→"わ" override)
-      2) spaced_hira: same morphological tokenization, but if token is 'は' particle => 'わ',
-         then convert the entire spaced string to hiragana.
-         (We do the "は"→"わ" override *before* converting to hiragana.)
-    If MeCab is not available, return (None, None).
+    Use MeCab for morphological analysis. Return four strings:
+      1) spaced_original: original surface forms joined by spaces.
+      2) spaced_hira_subbed: token text with the "は" particle overridden to "わ" where applicable, then converted to Hiragana.
+      3) spaced_hira_original: the Hiragana conversion of the original spaced text.
+      4) pos_tags: part-of-speech tags for each token (joined by spaces).
+    If MeCab is not available, return (None, None, None, None).
     """
     if not MECAB_AVAILABLE:
-        return None, None
+        return None, None, None, None
 
     tagger = MeCab.Tagger()
     node = tagger.parseToNode(text)
 
     tokens_original = []
     tokens_for_hira = []
+    pos_tokens = []
 
     while node:
         surface = node.surface
         features = node.feature.split(",")
-
         if len(features) >= 8:
             pos = features[0]  # e.g. 助詞, 名詞, 動詞...
-            # For "original spaced" version:
             tokens_original.append(surface)
-
-            # For "hira spaced" version, override if 助詞 and surface=="は"
+            pos_tokens.append(pos)
+            # Override if particle "は" (助詞)
             if pos == "助詞" and surface == "は":
                 tokens_for_hira.append("わ")
             else:
@@ -401,54 +399,52 @@ def mecab_spaced_reading(text: str) -> Tuple[Optional[str], Optional[str]]:
         else:
             tokens_original.append(surface)
             tokens_for_hira.append(surface)
-
+            pos_tokens.append("UNK")
         node = node.next
 
     spaced_original = " ".join(tokens_original)
     spaced_for_hira = " ".join(tokens_for_hira)
-
-    # Convert spaced_for_hira to Hiragana
+    pos_tags = " ".join(pos_tokens)
     spaced_hira_subbed = to_hiragana(spaced_for_hira)
+    # spaced_hira_original is computed here if needed later.
     spaced_hira_original = to_hiragana(spaced_original)
 
-    return spaced_original, spaced_hira_subbed, spaced_hira_original
+    return spaced_original, spaced_hira_subbed, spaced_hira_original, pos_tags
 
 
 # ========== 3) spaCy Morphological Tokenization ==========
-
 _spacy_nlp = None
 def load_spacy_japanese():
     """
-    Lazy-load the spaCy model. We'll call nlp() on it.
-    Requires 'ja_core_news_sm' or similar to be installed.
+    Lazy-load the spaCy model. Requires 'ja_core_news_sm' or similar to be installed.
     """
     global _spacy_nlp
     if _spacy_nlp is None:
         _spacy_nlp = spacy.load("ja_core_news_sm")
     return _spacy_nlp
 
-def spacy_spaced_reading(text: str) -> Tuple[Optional[str], Optional[str]]:
+def spacy_spaced_reading(text: str) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
     """
-    Use spaCy morphological analysis. Return two strings:
-      1) spaced_original: original token texts joined by spaces
-      2) spaced_hira: token texts but with "は"→"わ" override if pos_ == 'ADP',
-         then converted to Hiragana.
-    If spaCy is not available, return (None, None).
+    Use spaCy morphological analysis. Return four strings:
+      1) spaced_original: original token texts joined by spaces.
+      2) spaced_hira_subbed: token texts (with "は" overridden to "わ" when pos_ is ADP) converted to Hiragana.
+      3) spaced_hira_original: Hiragana conversion of the original spaced token texts.
+      4) pos_tags: part-of-speech tags (using token.pos_) joined by spaces.
+    If spaCy is not available, return (None, None, None, None).
     """
     if not SPACY_AVAILABLE:
-        return None, None
+        return None, None, None, None
 
     nlp = load_spacy_japanese()
     doc = nlp(text)
 
     tokens_original = []
     tokens_for_hira = []
+    pos_tokens = []
 
     for token in doc:
-        # Original token text
         tokens_original.append(token.text)
-
-        # For the hiragana version, override "は" if it's a particle (ADP)
+        pos_tokens.append(token.pos_)
         if token.text == "は" and token.pos_ == "ADP":
             tokens_for_hira.append("わ")
         else:
@@ -456,28 +452,24 @@ def spacy_spaced_reading(text: str) -> Tuple[Optional[str], Optional[str]]:
 
     spaced_original = " ".join(tokens_original)
     spaced_for_hira = " ".join(tokens_for_hira)
-
-    # Convert to Hiragana
+    pos_tags = " ".join(pos_tokens)
     spaced_hira_subbed = to_hiragana(spaced_for_hira)
     spaced_hira_original = to_hiragana(spaced_original)
 
-    return spaced_original, spaced_hira_subbed, spaced_hira_original
+    return spaced_original, spaced_hira_subbed, spaced_hira_original, pos_tags
 
 
 # ========== 4) Unified "get spaced reading" function ==========
-def get_spaced_reading(text: str, method: str) -> Tuple[Optional[str], Optional[str]]:
+def get_spaced_reading(text: str, method: str) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
     """
-    Return (spaced_original, spaced_hira) for the chosen method.
-    If method=='mecab', use MeCab.
-    If method=='spacy', use spaCy.
-    Otherwise (None, None).
+    Return (spaced_original, spaced_hira_subbed, spaced_hira_original, pos_tags) using the chosen method.
     """
     if method == "mecab":
         return mecab_spaced_reading(text)
     elif method == "spacy":
         return spacy_spaced_reading(text)
     else:
-        return None, None
+        return None, None, None, None
 
 
 # ========== 5) Main Processing Logic ==========
@@ -485,22 +477,21 @@ def process_japanese_text(
     input_file: str,
     output_file: str,
     json_inplace_update: bool = False,
-    json_input_field: str = "sentence",
-    json_output_field: str = "sentence_ipa",
     use_mecab: bool = False,
     use_spacy: bool = False,
 ):
     """
     Processes Japanese text to IPA.
-    - If JSON, each entry gets up to 5 fields:
-        1) {json_input_field} -> original text
-        2) {json_input_field}_spaced_original -> original text with spaces (NEW FIELD)
-        3) {json_input_field}_spaced -> morphological spaced text in HIRAGANA (with は=>わ override)
-        4) {json_output_field} -> IPA from unspaced
-        5) {json_output_field}_spaced -> IPA from spaced reading
-    - If plain text, we do similarly but just write out lines in textual format.
+    
+    Whether the input is a JSON array (with each object having a "sentence" field) or plain text (one sentence per line),
+    the output is a valid JSON array. Each output object has the following fields:
+      - sentence             : original sentence
+      - unspaced_ipa         : IPA conversion of the unspaced (raw) Hiragana reading
+      - spaced_original      : original sentence with morphological tokenization (tokens joined by spaces)
+      - spaced_hira_subbed   : tokenized sentence (with "は" overridden to "わ") in Hiragana
+      - pos_tags             : space-separated part-of-speech tags
+      - spaced_ipa           : IPA conversion of the spaced reading
     """
-
     # Decide morphological method:
     morph_method = None
     if use_mecab and use_spacy:
@@ -513,85 +504,78 @@ def process_japanese_text(
     else:
         morph_method = None
 
-    # JSON MODE
+    # If input is JSON, process as JSON array.
     if json_inplace_update:
         try:
             with open(input_file, "r", encoding="utf-8") as fin:
                 data = json.load(fin)
-
+            out_array = []
             for entry in tqdm(data, desc="Processing JSON entries"):
-                if json_input_field not in entry:
-                    # If the specified input field doesn't exist, skip
+                if "sentence" not in entry:
                     continue
-
-                original_text = entry[json_input_field]
-
-                # 1) Convert original_text -> Hiragana -> IPA (unspaced)
+                original_text = entry["sentence"]
+                # Compute unspaced IPA:
                 hira_unspaced = to_hiragana(original_text)
                 ipa_unspaced = hiragana_to_ipa(hira_unspaced)
-                entry[json_output_field] = ipa_unspaced
-
-                # 2) If morphological approach, get spaced readings
+                out_obj = {
+                    "sentence": original_text,
+                    "unspaced_ipa": ipa_unspaced,
+                    "spaced_original": "",
+                    "spaced_hira_subbed": "",
+                    "pos_tags": "",
+                    "spaced_ipa": ""
+                }
                 if morph_method is not None:
-                    spaced_original, spaced_hira_subbed, spaced_hira_original = get_spaced_reading(original_text, morph_method)
-                    if spaced_original is not None:
-                        # Add the new field: original text spaced
-                        entry[f"{json_input_field}_spaced_original"] = spaced_original
-
-                    if spaced_hira_original is not None:
-                        entry[f"{json_input_field}_spaced_original"] = spaced_hira_subbed
-                    if spaced_hira_subbed is not None:
-                        entry[f"{json_input_field}_spaced_subbed"] = spaced_hira_subbed
+                    spaced_original, spaced_hira_subbed, _, pos_tags = get_spaced_reading(original_text, morph_method)
+                    out_obj["spaced_original"]    = spaced_original if spaced_original is not None else ""
+                    out_obj["spaced_hira_subbed"]   = spaced_hira_subbed if spaced_hira_subbed is not None else ""
+                    out_obj["pos_tags"]             = pos_tags if pos_tags is not None else ""
+                    ipa_spaced = ""
+                    if spaced_hira_subbed:
                         ipa_spaced = hiragana_to_ipa(spaced_hira_subbed)
-                        entry[f"{json_output_field}_spaced"] = ipa_spaced
-
+                    out_obj["spaced_ipa"] = ipa_spaced
+                out_array.append(out_obj)
             with open(output_file, "w", encoding="utf-8") as fout:
-                json.dump(data, fout, ensure_ascii=False, indent=4)
-
+                json.dump(out_array, fout, ensure_ascii=False, indent=4)
         except FileNotFoundError:
             print(f"Error: Input file '{input_file}' not found.")
         except json.JSONDecodeError:
             print(f"Error: Invalid JSON format in '{input_file}'.")
         except Exception as e:
             print(f"An error occurred: {e}")
-
     else:
-        # PLAIN TEXT MODE
+        # Plain text input: each non-blank line is treated as a sentence.
         try:
             with open(input_file, "r", encoding="utf-8") as fin:
                 lines = fin.readlines()
-
+            out_array = []
+            for line in tqdm(lines, desc="Processing lines"):
+                line = line.strip()
+                if not line:
+                    continue
+                original_text = line
+                hira_unspaced = to_hiragana(original_text)
+                ipa_unspaced = hiragana_to_ipa(hira_unspaced)
+                out_obj = {
+                    "sentence": original_text,
+                    "unspaced_ipa": ipa_unspaced,
+                    "spaced_original": "",
+                    "spaced_hira_subbed": "",
+                    "pos_tags": "",
+                    "spaced_ipa": ""
+                }
+                if morph_method is not None:
+                    spaced_original, spaced_hira_subbed, _, pos_tags = get_spaced_reading(original_text, morph_method)
+                    out_obj["spaced_original"]    = spaced_original if spaced_original is not None else ""
+                    out_obj["spaced_hira_subbed"]   = spaced_hira_subbed if spaced_hira_subbed is not None else ""
+                    out_obj["pos_tags"]             = pos_tags if pos_tags is not None else ""
+                    ipa_spaced = ""
+                    if spaced_hira_subbed:
+                        ipa_spaced = hiragana_to_ipa(spaced_hira_subbed)
+                    out_obj["spaced_ipa"] = ipa_spaced
+                out_array.append(out_obj)
             with open(output_file, "w", encoding="utf-8") as fout:
-                for line in tqdm(lines, desc="Processing lines"):
-                    line = line.strip()
-                    if not line:
-                        fout.write("\n")
-                        continue
-
-                    # A) Unspaced -> IPA
-                    hira_unspaced = to_hiragana(line)
-                    ipa_unspaced = hiragana_to_ipa(hira_unspaced)
-
-                    if morph_method is not None:
-                        # B) Spaced reading
-                        spaced_original, spaced_hira_subbed, spaced_hira_original = get_spaced_reading(line, morph_method)
-                        ipa_spaced = ""
-                        if spaced_hira_subbed:
-                            ipa_spaced = hiragana_to_ipa(spaced_hira_subbed)
-
-                        fout.write(f"[Original]            : {line}\n")
-                        fout.write(f"[Unspaced IPA]        : {ipa_unspaced}\n")
-                        if spaced_original is not None:
-                            fout.write(f"[Spaced Original]     : {spaced_original}\n")
-                        if spaced_hira_original is not None:
-                            fout.write(f"[Spaced Hira Original]: {spaced_hira_original}\n")
-                        if spaced_hira_subbed is not None:
-                            fout.write(f"[Spaced Hira Subbed]  : {spaced_hira_subbed}\n")
-                        fout.write(f"[Spaced IPA]          : {ipa_spaced}\n\n")
-                    else:
-                        # No morphological approach, just print unspaced IPA
-                        fout.write(ipa_unspaced + "\n")
-
+                json.dump(out_array, fout, ensure_ascii=False, indent=4)
         except FileNotFoundError:
             print(f"Error: Input file '{input_file}' not found.")
         except Exception as e:
@@ -600,24 +584,22 @@ def process_japanese_text(
 
 # ========== 6) Command-Line Entry Point ==========
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Convert JP text to IPA, forcing 'は' particle => 'わ' using either MeCab or spaCy.")
+    parser = argparse.ArgumentParser(
+        description="Convert JP text to IPA with morphological spacing and POS tagging. "
+                    "Output is a JSON array with fields: sentence, unspaced_ipa, spaced_original, spaced_hira_subbed, pos_tags, spaced_ipa."
+    )
     parser.add_argument("input_file", nargs="?", default="input.txt",
-                        help="Path to the input file (text or JSON).")
-    parser.add_argument("output_file", nargs="?", default="output_ipa.txt",
-                        help="Path to the output file.")
+                        help="Path to the input file (JSON array with 'sentence' fields or plain text).")
+    parser.add_argument("output_file", nargs="?", default="output.json",
+                        help="Path to the output JSON file.")
 
     parser.add_argument("-j", "--json_inplace_update", action="store_true",
-                        help="Treat input file as JSON and update in-place with IPA fields.")
-    parser.add_argument("--json_input_field", default="sentence",
-                        help="JSON field for original text (default: sentence).")
-    parser.add_argument("--json_output_field", default="sentence_ipa",
-                        help="JSON field for IPA output (default: sentence_ipa).")
-
+                        help="Treat input file as JSON and update each entry with IPA and POS fields.")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--use_mecab", action="store_true",
-                       help="Use MeCab morphological approach for spacing and forcing 'は' => 'わ'.")
+                       help="Use MeCab for morphological tokenization (and forcing 'は' => 'わ').")
     group.add_argument("--use_spacy", action="store_true",
-                       help="Use spaCy morphological approach for spacing and forcing 'は' => 'わ'.")
+                       help="Use spaCy for morphological tokenization (and forcing 'は' => 'わ').")
 
     args = parser.parse_args()
 
@@ -625,8 +607,6 @@ if __name__ == "__main__":
         input_file=args.input_file,
         output_file=args.output_file,
         json_inplace_update=args.json_inplace_update,
-        json_input_field=args.json_input_field,
-        json_output_field=args.json_output_field,
         use_mecab=args.use_mecab,
         use_spacy=args.use_spacy
     )

--- a/data/template/utils/ja2ipa.py
+++ b/data/template/utils/ja2ipa.py
@@ -1,15 +1,32 @@
-from collections import OrderedDict
-import pykakasi.kakasi as kakasi
+#!/usr/bin/env python3
 import argparse
 import json
-from tqdm import tqdm
 import sys
+from collections import OrderedDict
 
-kakasi = kakasi()
-kakasi.setMode('J', 'H')  # J(Kanji) to H(Hiragana)
-kakasi.setMode('H', 'H') # H(Hiragana) to None(noconversion)
-kakasi.setMode('K', 'H') # K(Katakana) to a(Hiragana)
-conv = kakasi.getConverter()
+from tqdm import tqdm
+import pykakasi.kakasi as kakasi
+
+# 1) Attempt optional imports
+try:
+    import MeCab
+    MECAB_AVAILABLE = True
+except ImportError:
+    MECAB_AVAILABLE = False
+
+try:
+    import spacy
+    SPACY_AVAILABLE = True
+except ImportError:
+    SPACY_AVAILABLE = False
+
+
+# ========== Kakasi Converter Setup ==========
+kks = kakasi()
+kks.setMode('J', 'H')  # Kanji -> Hiragana
+kks.setMode('H', 'H')  # Hiragana -> Hiragana
+kks.setMode('K', 'H')  # Katakana -> Hiragana
+conv = kks.getConverter()
 
 kana_mapper = OrderedDict([
     ("ゔぁ","bˈa"),
@@ -334,47 +351,178 @@ nasal_sound = OrderedDict([
     
 ])
 
-def getRomeNameByHira(hira):
-    result = conv.do(hira)
-    return result
+# ========== Basic Conversions ==========
+def to_hiragana(text: str) -> str:
+    """Convert JP text to Hiragana via Kakasi."""
+    return conv.do(text)
 
-
-def hiragana2IPA(text):
-    orig = text
-
+def hiragana_to_ipa(text: str) -> str:
+    """Convert Hiragana to IPA using kana_mapper + nasal_sound."""
     for k, v in kana_mapper.items():
         text = text.replace(k, v)
-
     for k, v in nasal_sound.items():
         text = text.replace(k, v)
-        
     return text
 
-def process_japanese_text(input_file, output_file, json_inplace_update=False, json_input_field="sentence", json_output_field="sentence_ipa"):
-    """
-    Processes Japanese text, converting it to IPA. Handles both plain text and JSON input.
 
-    Args:
-        input_file (str): Path to the input file (text or JSON).
-        output_file (str): Path to the output file.
-        json_inplace_update (bool): If True, process JSON input and add IPA to the same JSON.
-        json_input_field (str): JSON field to read from (default: "sentence").
-        json_output_field (str): JSON field to write IPA to (default: "sentence_ipa").
+# ========== 2) MeCab Morphological Tokenization ==========
+def mecab_spaced_reading(text: str) -> str:
     """
+    Use MeCab for morphological analysis and produce a spaced reading.
+    Special override: if token is particle (助詞) and surface == "は",
+    we treat it as "わ" so final IPA becomes "wa" instead of "ha."
+    """
+    if not MECAB_AVAILABLE:
+        # If MeCab is not installed, fallback to the raw text
+        return text
 
+    tagger = MeCab.Tagger()
+    node = tagger.parseToNode(text)
+
+    tokens = []
+    while node:
+        surface = node.surface
+        features = node.feature.split(",")
+
+        # Typically: features = [pos, pos_sub1, pos_sub2, pos_sub3, conjugation, base_form, reading, pronunciation]
+        if len(features) >= 8:
+            pos = features[0]        # e.g. 名詞, 助詞, 動詞, 形容詞...
+            # base_form = features[6]
+            # reading   = features[7]
+            # If it's "助詞" and surface=="は", override
+            if pos == "助詞" and surface == "は":
+                tokens.append("わ")
+            else:
+                # Otherwise, just append surface
+                tokens.append(surface)
+        else:
+            # In rare cases, no features
+            tokens.append(surface)
+
+        node = node.next
+
+    # Join tokens with space
+    spaced_str = " ".join(tokens)
+    # Convert that entire spaced string to Hiragana (for any Kanji, Katakana)
+    spaced_hira = to_hiragana(spaced_str)
+    return spaced_hira
+
+
+# ========== 3) spaCy Morphological Tokenization ==========
+_spacy_nlp = None
+
+def load_spacy_japanese():
+    """
+    Lazy-load the spaCy model. We'll call nlp() on it.
+    Requires 'ja_core_news_sm' or similar to be installed.
+    """
+    global _spacy_nlp
+    if _spacy_nlp is None:
+        _spacy_nlp = spacy.load("ja_core_news_sm")
+    return _spacy_nlp
+
+def spacy_spaced_reading(text: str) -> str:
+    """
+    Use spaCy morphological analysis. If we see a token that is
+    'は' with pos_='ADP' (particle), override to 'わ'.
+    Then convert everything to Hiragana with Kakasi.
+    Join tokens by space.
+
+    (pos_='ADP' is typical for a particle in spaCy's universal POS, 
+     but check your model if it uses a different tag for JP.)
+    """
+    if not SPACY_AVAILABLE:
+        return text  # fallback if spaCy is not installed
+
+    nlp = load_spacy_japanese()
+    doc = nlp(text)
+
+    tokens = []
+    for token in doc:
+        # If it's the single character "は" and pos_ is ADP (a particle)
+        if token.text == "は" and token.pos_ == "ADP":
+            tokens.append("わ")
+        else:
+            tokens.append(token.text)
+
+    # Join, then convert to Hiragana
+    spaced_str = " ".join(tokens)
+    spaced_hira = to_hiragana(spaced_str)
+    return spaced_hira
+
+
+# ========== 4) Unified "get spaced reading" function ==========
+def get_spaced_reading(text: str, method: str) -> str:
+    """
+    If method=='mecab', use MeCab morphological approach.
+    If method=='spacy', use spaCy morphological approach.
+    Otherwise, return original text (no spacing).
+    """
+    if method == "mecab":
+        return mecab_spaced_reading(text)
+    elif method == "spacy":
+        return spacy_spaced_reading(text)
+    else:
+        # no morphological approach
+        return text
+
+
+# ========== 5) Main Processing Logic ==========
+def process_japanese_text(
+    input_file: str,
+    output_file: str,
+    json_inplace_update: bool = False,
+    json_input_field: str = "sentence",
+    json_output_field: str = "sentence_ipa",
+    use_mecab: bool = False,
+    use_spacy: bool = False,
+):
+    """
+    Processes Japanese text to IPA. 
+    - If JSON, each entry gets up to 4 fields:
+        1) {json_input_field} -> original text
+        2) {json_input_field}_spaced -> morphological spaced text (if use_mecab/use_spacy)
+        3) {json_output_field} -> IPA from unspaced
+        4) {json_output_field}_spaced -> IPA from spaced reading
+    - If plain text, we do similarly but just write out lines in a textual format.
+    """
+    # Decide morphological method:
+    morph_method = None
+    if use_mecab and use_spacy:
+        print("Error: Please choose either MeCab or spaCy, not both.")
+        sys.exit(1)
+    elif use_mecab:
+        morph_method = "mecab"
+    elif use_spacy:
+        morph_method = "spacy"
+    else:
+        morph_method = None
+
+    # JSON MODE
     if json_inplace_update:
         try:
-            with open(input_file, "r", encoding="utf-8") as f:
-                data = json.load(f)
+            with open(input_file, "r", encoding="utf-8") as fin:
+                data = json.load(fin)
 
             for entry in tqdm(data, desc="Processing JSON entries"):
-                if json_input_field in entry:
-                    kana = getRomeNameByHira(entry[json_input_field])
-                    ipa = hiragana2IPA(kana)
-                    entry[json_output_field] = ipa  # Add IPA to the same JSON entry
+                if json_input_field not in entry:
+                    continue
 
-            with open(output_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, ensure_ascii=False, indent=4)
+                original_text = entry[json_input_field]
+                # 1) Unspaced → IPA
+                hira_unspaced = to_hiragana(original_text)
+                ipa_unspaced = hiragana_to_ipa(hira_unspaced)
+                entry[json_output_field] = ipa_unspaced
+
+                # 2) If morphological approach, get spaced reading, then spaced IPA
+                if morph_method is not None:
+                    spaced_hira = get_spaced_reading(original_text, morph_method)
+                    entry[f"{json_input_field}_spaced"] = spaced_hira
+                    ipa_spaced = hiragana_to_ipa(spaced_hira)
+                    entry[f"{json_output_field}_spaced"] = ipa_spaced
+
+            with open(output_file, "w", encoding="utf-8") as fout:
+                json.dump(data, fout, ensure_ascii=False, indent=4)
 
         except FileNotFoundError:
             print(f"Error: Input file '{input_file}' not found.")
@@ -384,15 +532,33 @@ def process_japanese_text(input_file, output_file, json_inplace_update=False, js
             print(f"An error occurred: {e}")
 
     else:
+        # PLAIN TEXT MODE
         try:
-            with open(input_file, mode="r", encoding="utf-8") as f:
-                lines = f.readlines()
+            with open(input_file, "r", encoding="utf-8") as fin:
+                lines = fin.readlines()
 
-            with open(output_file, "w", encoding="utf-8") as outfile:
+            with open(output_file, "w", encoding="utf-8") as fout:
                 for line in tqdm(lines, desc="Processing lines"):
-                    kana = getRomeNameByHira(line.strip())
-                    ipa = hiragana2IPA(kana)
-                    outfile.write(ipa + "\n")
+                    line = line.strip()
+                    if not line:
+                        fout.write("\n")
+                        continue
+
+                    # A) Unspaced -> IPA
+                    hira_unspaced = to_hiragana(line)
+                    ipa_unspaced = hiragana_to_ipa(hira_unspaced)
+
+                    if morph_method is not None:
+                        # B) Spaced reading -> spaced IPA
+                        spaced_hira = get_spaced_reading(line, morph_method)
+                        ipa_spaced = hiragana_to_ipa(spaced_hira)
+
+                        fout.write(f"[Original]    : {line}\n")
+                        fout.write(f"[Unspaced IPA]: {ipa_unspaced}\n")
+                        fout.write(f"[Spaced Hira] : {spaced_hira}\n")
+                        fout.write(f"[Spaced IPA]  : {ipa_spaced}\n\n")
+                    else:
+                        fout.write(ipa_unspaced + "\n")
 
         except FileNotFoundError:
             print(f"Error: Input file '{input_file}' not found.")
@@ -400,14 +566,36 @@ def process_japanese_text(input_file, output_file, json_inplace_update=False, js
             print(f"An error occurred: {e}")
 
 
+# ========== 6) Command-Line Entry Point ==========
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Convert Japanese text to IPA.")
-    parser.add_argument("input_file", help="Path to the input Japanese text file (default: input.txt)", nargs="?", default="input.txt")
-    parser.add_argument("output_file", help="Path to the output IPA file (default: input_ipa.txt)", nargs="?", default="input_ipa.txt")
-    parser.add_argument("-j", "--json_inplace_update", action="store_true", help="Process JSON input and add IPA to the same JSON entries")
-    parser.add_argument("--json_input_field", default="sentence", help="JSON field to read from (default: sentence)")
-    parser.add_argument("--json_output_field", default="sentence_ipa", help="JSON field to write IPA to (default: sentence_ipa)")
+    parser = argparse.ArgumentParser(description="Convert JP text to IPA, forcing 'は' particle => 'わ' using either MeCab or spaCy.")
+    parser.add_argument("input_file", nargs="?", default="input.txt",
+                        help="Path to the input file (text or JSON).")
+    parser.add_argument("output_file", nargs="?", default="output_ipa.txt",
+                        help="Path to the output file.")
+
+    parser.add_argument("-j", "--json_inplace_update", action="store_true",
+                        help="Treat input file as JSON and update in-place with IPA fields.")
+    parser.add_argument("--json_input_field", default="sentence",
+                        help="JSON field for original text (default: sentence).")
+    parser.add_argument("--json_output_field", default="sentence_ipa",
+                        help="JSON field for IPA output (default: sentence_ipa).")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--use_mecab", action="store_true",
+                       help="Use MeCab morphological approach for spacing and forcing 'は' => 'わ'.")
+    group.add_argument("--use_spacy", action="store_true",
+                       help="Use spaCy morphological approach for spacing and forcing 'は' => 'わ'.")
 
     args = parser.parse_args()
 
-    process_japanese_text(args.input_file, args.output_file, args.json_inplace_update, args.json_input_field, args.json_output_field)
+    process_japanese_text(
+        input_file=args.input_file,
+        output_file=args.output_file,
+        json_inplace_update=args.json_inplace_update,
+        json_input_field=args.json_input_field,
+        json_output_field=args.json_output_field,
+        use_mecab=args.use_mecab,
+        use_spacy=args.use_spacy
+    )
+

--- a/data/template/utils/ja2ipa.py
+++ b/data/template/utils/ja2ipa.py
@@ -387,7 +387,7 @@ def mecab_spaced_reading(text: str) -> Tuple[Optional[str], Optional[str], Optio
     while node:
         surface = node.surface
         features = node.feature.split(",")
-        if len(features) >= 8:
+        if len(features) >= 1:
             pos = features[0]  # e.g. 助詞, 名詞, 動詞...
             tokens_original.append(surface)
             pos_tokens.append(pos)


### PR DESCRIPTION
Adding ipa spacing and part of speech.
This addresses the 'wa' vs 'ha' issue via part of speech analysis, and adds another parallel stream of data representation.

Example invocation:
```sh
python3 ja2ipa.py input.json output.json -j --use_mecab
```

![image](https://github.com/user-attachments/assets/253fb424-7bde-44f7-9302-8da4466d73b5)

Note the part of speech output is different between mecab and spacy.

