### PR TITLE
Integrate multicontext training

### DIFF
--- a/data/shakespeare_char_mobius/convert.py
+++ b/data/shakespeare_char_mobius/convert.py
@@ -1,0 +1,138 @@
+import string
+import argparse
+import re
+
+# For the 'pos' method:
+# Make sure to install NLTK (pip install nltk) and download the "averaged_perceptron_tagger" resource:
+# import nltk
+# nltk.download('punkt')
+# nltk.download('averaged_perceptron_tagger')
+import nltk
+
+def transform_basic(text):
+    """
+    The original basic transformation:
+      - Punctuation -> '1'
+      - Vowels -> '2'
+      - Consonants -> '3'
+      - Everything else -> '_'
+    """
+    punctuation = string.punctuation
+    vowels = 'aeiouAEIOU'
+    consonants = ''.join([c for c in string.ascii_letters if c not in vowels])
+
+    transformed = []
+    for char in text:
+        if char in punctuation:
+            transformed.append('1')
+        elif char in vowels:
+            transformed.append('2')
+        elif char in consonants:
+            transformed.append('3')
+        else:
+            # Whitespace, digits, etc.
+            transformed.append('_')
+    return ''.join(transformed)
+
+
+def transform_pos(text):
+    """
+    Naive POS-based transformation:
+      - Split the text into 'chunks' (words vs. whitespace) using a regex that preserves delimiters.
+      - For each non-whitespace chunk, run nltk.pos_tag([chunk]) to get a single (token, tag) pair.
+      - Convert the tag's first letter to lowercase (e.g. 'NN' -> 'n', 'VB' -> 'v') and
+        repeat it for each character in the chunk.
+      - For whitespace chunks, output underscores.
+      - Example: " dog cat" -> "_nnn_nnn"
+    """
+    # Split so that whitespace is kept as separate chunks
+    chunks = re.split(r'(\s+)', text)
+    transformed = []
+
+    for chunk in chunks:
+        if not chunk:
+            # Empty string (beginning or end) – skip or turn into ''
+            continue
+        if chunk.isspace():
+            # Turn each whitespace character into '_'
+            transformed.append('_' * len(chunk))
+        else:
+            # Tag this chunk as a single token (naive approach)
+            # If the chunk includes punctuation, pos_tag might label it differently,
+            # but we'll keep it simple here.
+            tagged = nltk.pos_tag([chunk])[0]  # returns (word, POS)
+            word, pos = tagged
+            # Take the first letter of the POS tag in lowercase
+            letter_for_pos = pos[0].lower()
+            # Repeat for each character in the chunk
+            transformed.append(letter_for_pos * len(chunk))
+
+    return ''.join(transformed)
+
+
+def transform_position(text):
+    """
+    Positional transformation:
+      - For each 'word' chunk (non-whitespace), replace each character with its 1-based position in that chunk.
+      - Whitespace becomes underscores.
+      - Example: " dog cat" -> "_123_123"
+    """
+    chunks = re.split(r'(\s+)', text)
+    transformed = []
+
+    for chunk in chunks:
+        if not chunk:
+            continue
+        if chunk.isspace():
+            # Replace each space with an underscore
+            transformed.append('_' * len(chunk))
+        else:
+            # Replace each character by 1-based position
+            out = []
+            for i, _ in enumerate(chunk):
+                out.append(str(i+1))
+            transformed.append(''.join(out))
+
+    return ''.join(transformed)
+
+
+def transform_file(filename, method):
+    """
+    Transforms a file in-place using the selected method.
+    """
+    try:
+        with open(filename, 'r+', encoding='utf-8') as file:
+            # Read the entire file content
+            file_content = file.read()
+
+            if method == 'basic':
+                transformed_content = transform_basic(file_content)
+            elif method == 'pos':
+                transformed_content = transform_pos(file_content)
+            elif method == 'position':
+                transformed_content = transform_position(file_content)
+            else:
+                raise ValueError(f"Unknown method: {method}")
+
+            # Overwrite file with transformed text
+            file.seek(0)
+            file.write(transformed_content)
+            file.truncate()
+
+    except FileNotFoundError:
+        print(f"Error: File '{filename}' not found.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Transform a text file by replacing characters.")
+    parser.add_argument("input_file", help="The input text file to transform.")
+    parser.add_argument(
+        "--method", 
+        choices=["basic", "pos", "position"],
+        default="basic",
+        help="Which transformation method to use."
+    )
+    args = parser.parse_args()
+
+    transform_file(args.input_file, args.method)
+

--- a/data/shakespeare_char_mobius/prepare.py
+++ b/data/shakespeare_char_mobius/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/shakespeare_char_order/convert.py
+++ b/data/shakespeare_char_order/convert.py
@@ -1,0 +1,143 @@
+import string
+import argparse
+import re
+import nltk
+
+# Make sure to install NLTK if using the 'pos' method and download taggers:
+# import nltk
+# nltk.download('punkt')
+# nltk.download('averaged_perceptron_tagger')
+
+# ------------------------------------------------------------------------
+# Original "basic" transformation function
+def transform_basic(text):
+    punctuation = string.punctuation
+    vowels = 'aeiouAEIOU'
+    consonants = ''.join([c for c in string.ascii_letters if c not in vowels])
+
+    transformed = []
+    for char in text:
+        if char in punctuation:
+            transformed.append('1')
+        elif char in vowels:
+            transformed.append('2')
+        elif char in consonants:
+            transformed.append('3')
+        else:
+            transformed.append('_')
+    return ''.join(transformed)
+
+# ------------------------------------------------------------------------
+# "pos" transformation function (optional, requires nltk)
+def transform_pos(text):
+    # Split so that whitespace is preserved as separate chunks
+    chunks = re.split(r'(\s+)', text)
+    transformed = []
+
+    for chunk in chunks:
+        if not chunk:
+            continue
+        if chunk.isspace():
+            # Turn each whitespace character into '_'
+            transformed.append('_' * len(chunk))
+        else:
+            # Tag this chunk (treated as one token)
+            tagged = nltk.pos_tag([chunk])[0]  # (token, POS)
+            _, pos = tagged
+            # Use the first letter of the POS tag, in lowercase, repeated per character
+            letter_for_pos = pos[0].lower()
+            transformed.append(letter_for_pos * len(chunk))
+
+    return ''.join(transformed)
+
+# ------------------------------------------------------------------------
+# New "position" transformation with single-character-per-position
+def transform_position(text):
+    """
+    For each non-whitespace 'word', replace each character with
+    a single character representing its 1-based position:
+      Positions 1-9  -> '1'..'9'
+      Positions 10-35 -> 'A'..'Z'
+      Positions 36-61 -> 'a'..'z'
+      If you exceed 61, wrap around to the start (modulo).
+    Whitespace remains underscores.
+    Example:
+      " dog cat" -> "_123_123"
+    """
+
+    # Our lookup table for positions (you can adjust or expand as desired)
+    #  - 1..9 = digits
+    #  - 10..35 = uppercase letters
+    #  - 36..61 = lowercase letters
+    position_chars = (
+        "123456789"            # (pos 1-9)
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"  # (pos 10-35)
+        "abcdefghijklmnopqrstuvwxyz"  # (pos 36-61)
+    )
+    max_index = len(position_chars)  # 61
+
+    # Split so that whitespace is preserved as separate chunks
+    chunks = re.split(r'(\s+)', text)
+    transformed = []
+
+    for chunk in chunks:
+        if not chunk:
+            # Empty string, possibly from a split edge
+            continue
+
+        if chunk.isspace():
+            # Turn each whitespace character into '_'
+            transformed.append('_' * len(chunk))
+        else:
+            # Replace each character by the appropriate single char from our table
+            out = []
+            for i, _ in enumerate(chunk, start=1):
+                # i is 1-based position, modulo with the table length
+                # (i - 1) % max_index ensures we start from index 0
+                idx = (i - 1) % max_index
+                out.append(position_chars[idx])
+            transformed.append(''.join(out))
+
+    return ''.join(transformed)
+
+# ------------------------------------------------------------------------
+def transform_file(filename, method):
+    """
+    Transforms a file in-place using the selected method.
+    """
+    try:
+        with open(filename, 'r+', encoding='utf-8') as file:
+            # Read the entire file content
+            file_content = file.read()
+
+            if method == 'basic':
+                transformed_content = transform_basic(file_content)
+            elif method == 'pos':
+                transformed_content = transform_pos(file_content)
+            elif method == 'position':
+                transformed_content = transform_position(file_content)
+            else:
+                raise ValueError(f"Unknown method: {method}")
+
+            # Overwrite file with transformed text
+            file.seek(0)
+            file.write(transformed_content)
+            file.truncate()
+
+    except FileNotFoundError:
+        print(f"Error: File '{filename}' not found.")
+
+# ------------------------------------------------------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Transform a text file by replacing characters.")
+    parser.add_argument("input_file", help="The input text file to transform.")
+    parser.add_argument(
+        "--method", 
+        choices=["basic", "pos", "position"],
+        default="basic",
+        help="Which transformation method to use."
+    )
+    args = parser.parse_args()
+
+    transform_file(args.input_file, args.method)
+

--- a/data/shakespeare_char_order/prepare.py
+++ b/data/shakespeare_char_order/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/shakespeare_char_pos_2/convert.py
+++ b/data/shakespeare_char_pos_2/convert.py
@@ -1,0 +1,138 @@
+import string
+import argparse
+import re
+
+# For the 'pos' method:
+# Make sure to install NLTK (pip install nltk) and download the "averaged_perceptron_tagger" resource:
+# import nltk
+# nltk.download('punkt')
+# nltk.download('averaged_perceptron_tagger')
+import nltk
+
+def transform_basic(text):
+    """
+    The original basic transformation:
+      - Punctuation -> '1'
+      - Vowels -> '2'
+      - Consonants -> '3'
+      - Everything else -> '_'
+    """
+    punctuation = string.punctuation
+    vowels = 'aeiouAEIOU'
+    consonants = ''.join([c for c in string.ascii_letters if c not in vowels])
+
+    transformed = []
+    for char in text:
+        if char in punctuation:
+            transformed.append('1')
+        elif char in vowels:
+            transformed.append('2')
+        elif char in consonants:
+            transformed.append('3')
+        else:
+            # Whitespace, digits, etc.
+            transformed.append('_')
+    return ''.join(transformed)
+
+
+def transform_pos(text):
+    """
+    Naive POS-based transformation:
+      - Split the text into 'chunks' (words vs. whitespace) using a regex that preserves delimiters.
+      - For each non-whitespace chunk, run nltk.pos_tag([chunk]) to get a single (token, tag) pair.
+      - Convert the tag's first letter to lowercase (e.g. 'NN' -> 'n', 'VB' -> 'v') and
+        repeat it for each character in the chunk.
+      - For whitespace chunks, output underscores.
+      - Example: " dog cat" -> "_nnn_nnn"
+    """
+    # Split so that whitespace is kept as separate chunks
+    chunks = re.split(r'(\s+)', text)
+    transformed = []
+
+    for chunk in chunks:
+        if not chunk:
+            # Empty string (beginning or end) – skip or turn into ''
+            continue
+        if chunk.isspace():
+            # Turn each whitespace character into '_'
+            transformed.append('_' * len(chunk))
+        else:
+            # Tag this chunk as a single token (naive approach)
+            # If the chunk includes punctuation, pos_tag might label it differently,
+            # but we'll keep it simple here.
+            tagged = nltk.pos_tag([chunk])[0]  # returns (word, POS)
+            word, pos = tagged
+            # Take the first letter of the POS tag in lowercase
+            letter_for_pos = pos[0].lower()
+            # Repeat for each character in the chunk
+            transformed.append(letter_for_pos * len(chunk))
+
+    return ''.join(transformed)
+
+
+def transform_position(text):
+    """
+    Positional transformation:
+      - For each 'word' chunk (non-whitespace), replace each character with its 1-based position in that chunk.
+      - Whitespace becomes underscores.
+      - Example: " dog cat" -> "_123_123"
+    """
+    chunks = re.split(r'(\s+)', text)
+    transformed = []
+
+    for chunk in chunks:
+        if not chunk:
+            continue
+        if chunk.isspace():
+            # Replace each space with an underscore
+            transformed.append('_' * len(chunk))
+        else:
+            # Replace each character by 1-based position
+            out = []
+            for i, _ in enumerate(chunk):
+                out.append(str(i+1))
+            transformed.append(''.join(out))
+
+    return ''.join(transformed)
+
+
+def transform_file(filename, method):
+    """
+    Transforms a file in-place using the selected method.
+    """
+    try:
+        with open(filename, 'r+', encoding='utf-8') as file:
+            # Read the entire file content
+            file_content = file.read()
+
+            if method == 'basic':
+                transformed_content = transform_basic(file_content)
+            elif method == 'pos':
+                transformed_content = transform_pos(file_content)
+            elif method == 'position':
+                transformed_content = transform_position(file_content)
+            else:
+                raise ValueError(f"Unknown method: {method}")
+
+            # Overwrite file with transformed text
+            file.seek(0)
+            file.write(transformed_content)
+            file.truncate()
+
+    except FileNotFoundError:
+        print(f"Error: File '{filename}' not found.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Transform a text file by replacing characters.")
+    parser.add_argument("input_file", help="The input text file to transform.")
+    parser.add_argument(
+        "--method", 
+        choices=["basic", "pos", "position"],
+        default="basic",
+        help="Which transformation method to use."
+    )
+    args = parser.parse_args()
+
+    transform_file(args.input_file, args.method)
+

--- a/data/shakespeare_char_pos_2/prepare.py
+++ b/data/shakespeare_char_pos_2/prepare.py
@@ -1,0 +1,1 @@
+../template/prepare.py

--- a/data/shakespeare_char_punct/convert.py
+++ b/data/shakespeare_char_punct/convert.py
@@ -1,0 +1,51 @@
+import string
+import argparse
+
+def transform_file(filename):
+  """
+  Transforms a file in-place, applying the following transformations:
+    - Punctuation becomes '1'
+    - Vowels become '2'
+    - Consonants become '3'
+    - Everything else becomes '_'
+
+  Args:
+    filename: The name of the file to transform.
+  """
+
+  punctuation = string.punctuation
+  vowels = 'aeiouAEIOU'
+  consonants = ''.join([c for c in string.ascii_letters if c not in vowels])
+
+  try:
+    with open(filename, 'r+') as file:
+      # Read the entire file content
+      file_content = file.read()
+
+      transformed_content = ''
+      for char in file_content:
+        if char in punctuation:
+          transformed_content += '1'
+        elif char in vowels:
+          transformed_content += '2'
+        elif char in consonants:
+          transformed_content += '3'
+        else:
+          transformed_content += '_'
+
+      # Go back to the beginning of the file
+      file.seek(0)
+      # Write the transformed content
+      file.write(transformed_content)
+      # Truncate the file in case the new content is shorter
+      file.truncate()
+
+  except FileNotFoundError:
+    print(f"Error: File '{filename}' not found.")
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Transform a text file by replacing characters.")
+  parser.add_argument("input_file", help="The input text file to transform.")
+  args = parser.parse_args()
+
+  transform_file(args.input_file)

--- a/data/shakespeare_char_punct/prepare.py
+++ b/data/shakespeare_char_punct/prepare.py
@@ -1,0 +1,68 @@
+"""
+Prepare the Shakespeare dataset for character-level language modeling.
+So instead of encoding with GPT-2 BPE tokens, we just map characters to ints.
+Will save train.bin, val.bin containing the ids, and meta.pkl containing the
+encoder and decoder and some other related info.
+"""
+import os
+import pickle
+import requests
+import numpy as np
+
+# download the tiny shakespeare dataset
+input_file_path = os.path.join(os.path.dirname(__file__), 'input.txt')
+if not os.path.exists(input_file_path):
+    data_url = 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt'
+    with open(input_file_path, 'w') as f:
+        f.write(requests.get(data_url).text)
+
+with open(input_file_path, 'r') as f:
+    data = f.read()
+print(f"length of dataset in characters: {len(data):,}")
+
+# get all the unique characters that occur in this text
+chars = sorted(list(set(data)))
+vocab_size = len(chars)
+print("all the unique characters:", ''.join(chars))
+print(f"vocab size: {vocab_size:,}")
+
+# create a mapping from characters to integers
+stoi = { ch:i for i,ch in enumerate(chars) }
+itos = { i:ch for i,ch in enumerate(chars) }
+def encode(s):
+    return [stoi[c] for c in s] # encoder: take a string, output a list of integers
+def decode(l):
+    return ''.join([itos[i] for i in l]) # decoder: take a list of integers, output a string
+
+# create the train and test splits
+n = len(data)
+train_data = data[:int(n*0.9)]
+val_data = data[int(n*0.9):]
+
+# encode both to integers
+train_ids = encode(train_data)
+val_ids = encode(val_data)
+print(f"train has {len(train_ids):,} tokens")
+print(f"val has {len(val_ids):,} tokens")
+
+# export to bin files
+train_ids = np.array(train_ids, dtype=np.uint16)
+val_ids = np.array(val_ids, dtype=np.uint16)
+train_ids.tofile(os.path.join(os.path.dirname(__file__), 'train.bin'))
+val_ids.tofile(os.path.join(os.path.dirname(__file__), 'val.bin'))
+
+# save the meta information as well, to help us encode/decode later
+meta = {
+    'vocab_size': vocab_size,
+    'itos': itos,
+    'stoi': stoi,
+}
+with open(os.path.join(os.path.dirname(__file__), 'meta.pkl'), 'wb') as f:
+    pickle.dump(meta, f)
+
+# length of dataset in characters:  1115394
+# all the unique characters:
+#  !$&',-.3:;?ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
+# vocab size: 65
+# train has 1003854 tokens
+# val has 111540 tokens

--- a/demos/multicontext_training.sh
+++ b/demos/multicontext_training.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+# TODO: prepare each of the datasets used for below
+
+python3 train.py \
+  --gns_type exact \
+  --training_mode multicontext \
+  --multicontext \
+  --multicontext_datasets "shakespeare_char" "shakespeare_char_mobius" "shakespeare_char_order" "shakespeare_char_pos_2" \
+  --vocab_sizes 65 256 24 16
+

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -12,6 +12,10 @@ class GPTConfig:
     n_kv_group: int = 12
     n_embd: int = 768
 
+    # For multicontext training
+    multicontext: bool = False
+    vocab_sizes: List[int] = field(default_factory=lambda: []) # Used in place of vocab
+
     # Steering Vectors
     ## Where to intercept
     apply_vector_at_layer_idx: int = None

--- a/model.py
+++ b/model.py
@@ -463,17 +463,12 @@ class GPT(nn.Module):
                                 ignore_index=-1
                                 )
                             )
-                # TODO: have selectable weights per loss, and possibly scheduled weights, or dynamic (depending on accuracy) weights
-                loss = sum(losses) / len(losses)
 
             else:
-                # TODO: refactor to be equiv
-                # Possibly just compute the last position in inference mode
-                logits_a = logits_a[:, [-1], :]
-                logits_b = logits_b[:, [-1], :]
-                loss_a = None
-                loss_b = None
-                loss = None
+                # only forward lm head on very last position in inference mode
+                for i in range(len(token_list)):
+                    logits.append(self.transformer[f'lm_head_{i}'](x[:, [-1], :]))
+                losses = None
 
             return logits, losses
 

--- a/train.py
+++ b/train.py
@@ -526,7 +526,9 @@ class Trainer:
                 self.train_data_dict[dataset] = train_data
                 self.val_data_dict[dataset] = val_data
                 # For multi-dataset case, store the token count for each dataset in a dictionary.
-                self.dataset_size_tokens = {d: len(self.train_data_dict[d]) for d in self.args.dataset_list}
+            print(self.train_data_dict, self.args.dataset_list)
+            print({d: len(self.train_data_dict[d]) for d in self.args.dataset_list})
+            self.dataset_size_tokens = {d: len(self.train_data_dict[d]) for d in self.args.dataset_list}
         else:
             if self.model_args['vocab_size'] is None:
                 sys.exit("Error: no vocab size specified")
@@ -557,7 +559,7 @@ class Trainer:
 
         def get_transitioned_probs():
             initial_probs = np.array(self.args.dataset_sampling_probs)
-            if self.args.final_dataset_sampling_probs:
+            if self.args.dataset_sampling_probs_final:
                 step_ratio = self.iter_num / self.args.max_iters
                 final_probs = np.array(self.args.dataset_sampling_probs_final)
                 return interpolate_probs(initial_probs, final_probs, self.args.transition_method, step_ratio)

--- a/train.py
+++ b/train.py
@@ -74,6 +74,8 @@ class Trainer:
             self.args.dataset = self.args.dataset_list[0]
             print(self.args.dataset)
 
+        if self.args.training_mode == 'multicontext':
+            self.vocab_sizes = {}
         # init optimizer and scheduler
         self.optimizer = None
         self.scheduler = None
@@ -432,6 +434,7 @@ class Trainer:
             with torch.no_grad():
                 for _ in range(max_sample_tokens):
                     x_cond = x if x.size(1) <= self.args.block_size else x[:, -self.args.block_size:]
+                    # TODO: make compatible with multidatset and multicontext
                     logits, _ = self.model(x_cond, iter_num=self.iter_num)
                     logits = logits[:, -1, :]
                     probs = torch.softmax(logits, dim=-1)
@@ -471,21 +474,27 @@ class Trainer:
 
     def load_data(self):
 
-        if self.args.dataset_list is None:
-
-            if self.model_args['vocab_size'] is None:
-                sys.exit("Error: no vocab size specified")
-            elif self.model_args['vocab_size'] == 100277:
-                # cl100k_base, vocab size 100277, requires np.uint32
-                self.train_data = np.memmap(os.path.join('data', self.args.dataset, 'train.bin'), dtype=np.uint32, mode='r')
-                self.val_data = np.memmap(os.path.join('data', self.args.dataset, 'val.bin'), dtype=np.uint32, mode='r')
-            else:
-                # all other tokenations so far require only np.uint16
-                self.train_data = np.memmap(os.path.join('data', self.args.dataset, 'train.bin'), dtype=np.uint16, mode='r')
-                self.val_data = np.memmap(os.path.join('data', self.args.dataset, 'val.bin'), dtype=np.uint16, mode='r')
-            # Store total token count for the single dataset.
-            self.dataset_size_tokens = len(self.train_data)
-        else:
+        if self.args.training_mode == 'multicontext':
+            # Expecting --multicontext_datasets to be provided.
+            if self.args.multicontext_datasets is None:
+                sys.exit("Error: When training_mode is 'multicontext', please provide --multicontext_datasets.")
+            self.train_data_dict = {}
+            self.val_data_dict = {}
+            for dataset in self.args.multicontext_datasets:
+                meta_path = os.path.join('data', dataset, 'meta.pkl')
+                if not os.path.exists(meta_path):
+                    sys.exit(f"Error: Meta file not found at {meta_path}")
+                with open(meta_path, 'rb') as f:
+                    meta = pickle.load(f)
+                    vocab_size = meta.get('vocab_size', None)
+                    print(vocab_size, dataset)
+                    self.vocab_sizes[dataset] = meta['vocab_size']
+                # Here we use np.uint16 for most datasets:
+                self.train_data_dict[dataset] = np.memmap(os.path.join('data', dataset, 'train.bin'), dtype=np.uint16, mode='r')
+                self.val_data_dict[dataset]   = np.memmap(os.path.join('data', dataset, 'val.bin'), dtype=np.uint16, mode='r')
+            # Also store total token counts per dataset.
+            self.dataset_size_tokens = {d: len(self.train_data_dict[d]) for d in self.args.multicontext_datasets}
+        if self.args.training_mode == 'multidataset':
             self.train_data_dict = {}
             self.val_data_dict = {}
 
@@ -517,8 +526,21 @@ class Trainer:
                 # Store in dictionaries
                 self.train_data_dict[dataset] = train_data
                 self.val_data_dict[dataset] = val_data
-            # For multi-dataset case, store the token count for each dataset in a dictionary.
-            self.dataset_size_tokens = {d: len(self.train_data_dict[d]) for d in self.args.dataset_list}
+                # For multi-dataset case, store the token count for each dataset in a dictionary.
+                self.dataset_size_tokens = {d: len(self.train_data_dict[d]) for d in self.args.dataset_list}
+        else:
+            if self.model_args['vocab_size'] is None:
+                sys.exit("Error: no vocab size specified")
+            elif self.model_args['vocab_size'] == 100277:
+                # cl100k_base, vocab size 100277, requires np.uint32
+                self.train_data = np.memmap(os.path.join('data', self.args.dataset, 'train.bin'), dtype=np.uint32, mode='r')
+                self.val_data = np.memmap(os.path.join('data', self.args.dataset, 'val.bin'), dtype=np.uint32, mode='r')
+            else:
+                # all other tokenations so far require only np.uint16
+                self.train_data = np.memmap(os.path.join('data', self.args.dataset, 'train.bin'), dtype=np.uint16, mode='r')
+                self.val_data = np.memmap(os.path.join('data', self.args.dataset, 'val.bin'), dtype=np.uint16, mode='r')
+            # Store total token count for the single dataset.
+            self.dataset_size_tokens = len(self.train_data)
 
 
     def get_batch(self, split, target_dataset=None):
@@ -542,7 +564,38 @@ class Trainer:
                 return interpolate_probs(initial_probs, final_probs, self.args.transition_method, step_ratio)
             return initial_probs
 
-        if self.args.dataset_list:
+        if self.args.training_mode == 'multicontext':
+            x_dict = {}
+            y_dict = {}
+            ix = None
+            # For each context/dataset, grab a batch
+            for dataset_name in self.args.multicontext_datasets:
+                data = (self.train_data_dict[dataset_name] 
+                        if split == 'train' else self.val_data_dict[dataset_name])
+                if ix is None:
+                    ix = torch.randint(len(data) - self.args.block_size, (self.args.batch_size,))
+                # pick random offset
+                x = torch.stack([
+                    torch.from_numpy(data[i : i+self.args.block_size].astype(np.int64)) 
+                    for i in ix
+                ])
+                y = torch.stack([
+                    torch.from_numpy(data[i+1 : i+1+self.args.block_size].astype(np.int64)) 
+                    for i in ix
+                ])
+                # Move to device
+                if self.device_type == 'cuda':
+                    x = x.pin_memory().to(self.device, non_blocking=True)
+                    y = y.pin_memory().to(self.device, non_blocking=True)
+                else:
+                    x, y = x.to(self.device), y.to(self.device)
+
+                x_dict[dataset_name] = x
+                y_dict[dataset_name] = y
+
+            return x_dict, y_dict, list(self.args.multicontext_datasets)
+
+        elif self.args.training_mode == "multidataset":
             # If multi-dataset sampling is enabled, pick a dataset using sampling probabilities
             if target_dataset:
                 dataset = target_dataset
@@ -610,6 +663,7 @@ class Trainer:
                 dataset_index = self.args.dataset_list.index(dataset)
                 self.args.learning_rate = self.args.dataset_sampling_learning_rate[dataset_index]
 
+
         else:
             # Else use the 'dataset' arg by default for backwards compatibility
             dataset = self.args.dataset
@@ -675,22 +729,6 @@ class Trainer:
         return x, y, dataset
 
     @torch.no_grad()
-    def custom_loss_with_top1_focus(self, logits, targets):
-        # Compute standard cross-entropy loss
-        ce_loss = torch.nn.functional.cross_entropy(logits, targets)
-
-        # Get the top-1 predictions
-        top1_preds = torch.argmax(logits, dim=-1)
-
-        # Focus more on the top-1 prediction by adding an additional term
-        correct_top1 = (top1_preds == targets).float()  # 1 for correct, 0 for incorrect
-        top1_focus_loss = 1.0 - correct_top1  # Emphasize the wrong top-1 predictions
-
-        # Combine the original cross-entropy loss and the top-1 focus term
-        loss = ce_loss + 0.5 * top1_focus_loss.mean()  # Adjust the weight (0.5) as needed
-        return loss
-
-    @torch.no_grad()
     def estimate_loss(self):
         out = {'datasets':{}}
 
@@ -716,6 +754,37 @@ class Trainer:
             out['val_std'] = out['datasets'][self.args.dataset]['val_std']
             out['train'] = out['datasets'][self.args.dataset]['train']
             out['train_std'] = out['datasets'][self.args.dataset]['train_std']
+        elif self.args.training_mode == "multicontext":
+            # multicontext training
+            for split in ['train', 'val']:
+                losses = {}
+                means = {}
+                mean_avg = 0.0
+                loss_std = 0.0
+                dataset_list = None
+                for i in range(len(self.args.multicontext_datasets)):
+                    losses[f"{i}"] = torch.zeros(self.args.eval_iters)
+                    means[f"{i}"] = 0.0
+
+                for k in range(self.args.eval_iters):
+                    x_dict, y_dict, dataset_list = self.get_batch(split)
+
+                    with self.ctx:
+                        logits, loss_list = self.model(None, token_dict=x_dict, target_dict=y_dict, iter_num=self.iter_num)
+                    for i in range(len(self.args.multicontext_datasets)):
+                        losses[f"{i}"][k] = loss_list[i]
+
+                for i in range(len(self.args.multicontext_datasets)):
+                    means[f"{i}"] = losses[f"{i}"].mean().item()
+                    mean_avg += means[f"{i}"]
+                    loss_std += losses[f"{i}"].std()
+
+
+                out[split] = np.array(mean_avg / len(self.args.multicontext_datasets))
+                for i, dataset in enumerate(self.args.multicontext_datasets):
+                    out[f"{split}_loss_{dataset}"] = means[f"{i}"]
+
+                out[split + "_std"] = np.array(loss_std / len(self.args.multicontext_datasets))
         else:
             # Default behavior for a single dataset
             for split in ['train', 'val']:
@@ -913,7 +982,11 @@ class Trainer:
         torch.save(checkpoint, os.path.join(self.args.out_dir, filename))
 
     def train(self):
-        self.X, self.Y, current_dataset = self.get_batch('train')
+        if self.args.training_mode == 'multicontext':
+            self.X_dict, self.Y_dict, dataset_list = self.get_batch('train')
+            current_dataset = dataset_list[0]
+        else:
+            self.X, self.Y, current_dataset = self.get_batch('train')
         t0 = time.time()
         local_iter_num = 0
         running_mfu = -1.0
@@ -1024,10 +1097,12 @@ class Trainer:
                         self.model.require_backward_grad_sync = (micro_step == self.args.gradient_accumulation_steps - 1)
 
                     with self.ctx:
-                        logits, loss = self.model(self.X, self.Y, iter_num=self.iter_num)
-
-                        if self.args.focus_on_top1_loss:
-                            loss = self.custom_loss_with_top1_focus(logits, self.Y)  # Use custom loss
+                        if self.args.training_mode == 'multicontext':
+                            total_loss = 0
+                            logits, losses = self.model(None, token_dict=self.X_dict, target_dict=self.Y_dict, iter_num=self.iter_num)
+                            loss = sum(losses)/len(losses)
+                        else:
+                            logits, loss = self.model(self.X, targets=self.Y, iter_num=self.iter_num)
 
                         loss = loss / self.args.gradient_accumulation_steps
 
@@ -1052,7 +1127,11 @@ class Trainer:
                     # measure grad norms
                     self.get_gradient_stats()
 
-                    self.X, self.Y, current_dataset = self.get_batch('train')
+                    if self.args.training_mode == 'multicontext':
+                        self.X_dict, self.Y_dict, dataset_list = self.get_batch('train')
+                        current_dataset = dataset_list[0]
+                    else:
+                        self.X, self.Y, current_dataset = self.get_batch('train')
 
                     if self.args.gns_type is not None:
                         approx_gns_results = gather_hook_results(self.model)

--- a/train_args.py
+++ b/train_args.py
@@ -51,14 +51,29 @@ def parse_args():
     training_group.add_argument('--csv_ckpt_dir', default='', type=str)
     training_group.add_argument('--init_from_ckpt', default='ckpt.pt', type=str, help="if save_major_ckpt_interval was set, can use to init from specific ckpts")
 
+    # Training modes
+    # TODO: find a way to merge this with the multicontext arg
+    training_group.add_argument(
+        '--training_mode',
+        default='single',
+        choices=['single', 'multidataset', 'multicontext'],
+        help="Training mode to use. 'multidataset' uses sequential sampling from multiple datasets. 'multicontext' processes multiple contexts simultaneously."
+    )
+
     # Data args
     training_group.add_argument('--dataset', default='shakespeare_char', type=str)
     training_group.add_argument('--batch_size', default=64, type=int)
     training_group.add_argument("--seed", default=1337, type=int)
 
-    # New: total tokens in dataset (for computing epochs) and sampling method
-    training_group.add_argument('--dataset_size_tokens', default=None, type=int,
-        help="Total number of tokens in the dataset (used for reporting epoch progress)")
+    # Multicontext Training Dataset args
+    model_group.add_argument('--multicontext', default=False, action=argparse.BooleanOptionalAction,
+                                    help="Enable multi-context training on multiple simultaneous datasets")
+    training_group.add_argument('--multicontext_datasets', default=None, nargs='+', type=str,
+                                    help="List of datasets to train on in multi-context mode (e.g., --multicontext_datasets shakespeare wikitext103 openwebtext)")
+    model_group.add_argument('--vocab_sizes', default=None, nargs='+', type=int,
+                                    help="List of vocabulary sizes for each dataset in --multicontext_datasets")
+
+    # Batch sampling args
     training_group.add_argument('--sampling_method', default="random",
         choices=["random", "sequential", "without_replacement"],
         help="Sampling method for get_batch: 'random' (with replacement), 'sequential' (without shuffling), or 'without_replacement' (shuffled without replacement)")

--- a/train_args.py
+++ b/train_args.py
@@ -1,6 +1,11 @@
 # train_args.py
 import argparse
 import math
+import re
+
+def clean_dataset_path(dataset_name):
+    """Removes leading './data/' or 'data/' from dataset paths."""
+    return re.sub(r'^(?:\./)?data/', '', dataset_name)
 
 def parse_args():
 
@@ -611,6 +616,17 @@ def parse_args():
     if args.save_config_json is not None:
         with open(args.save_config_json, 'w') as json_file:
             json.dump(vars(args), json_file)
+
+    # Apply cleaning to dataset arguments
+    if args.dataset:
+        args.dataset = clean_dataset_path(args.dataset)
+    print(args.dataset)
+    if args.dataset_list:
+        args.dataset_list = [clean_dataset_path(ds) for ds in args.dataset_list]
+    if args.multicontext_datasets:
+        print(args.multicontext_datasets)
+        args.multicontext_datasets = [clean_dataset_path(ds) for ds in args.multicontext_datasets]
+        print(args.multicontext_datasets)
 
     return args, model_group, training_group, logging_group
 


### PR DESCRIPTION
# Multiembedding Training

This PR allows for training of multiple datasets in parallel.

While this currently works, there are some todos remaining:
- [ ] print to std out and log to tensorboard per context validation and training losses
- [ ] readme files for each of the new converter scripts (and updates for the prepare.py/get_dataset for each)
- [ ] General readme for this feature.
- [ ] simplify implementation
- [ ] sample.py adjustments for the printing out the predicted values

Example invocation:
```sh
python3 train.py \
  --gns_type exact \
  --training_mode multicontext \
  --multicontext \
  --multicontext_datasets "shakespeare_char" "shakespeare_char_mobius" "shakespeare_char_order" "shakespeare_char_pos_2" \
  --vocab_sizes 65 256 24 16
```
![image](https://github.com/user-attachments/assets/2011c723-cb77-4c0e-90ea-62ca501979be)

It also introduces training modes, so we now have to specify training_mode for multidataset and multicontext training. 

Note this has minimal impact on the actual param count:
![image](https://github.com/user-attachments/assets/ee2c97f5-342d-4f2d-b580-be8e0d90815b)

![image](https://github.com/user-attachments/assets/7f43165a-d96e-4542-ad30-391523bfd244)

Also note that some of the parallel embeddings have significant lasting impact on training_loss curves.
![image](https://github.com/user-attachments/assets/7bb28dde-594f-42cb-88fc-2e3b102d0296)

