### PR TITLE
Adding graph outputs of the model

### DIFF
--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -10,3 +10,5 @@ tiktoken==0.7.0
 torchinfo==1.8.0
 transformers==4.44.2
 wandb==0.18.3
+onnx==1.17.0
+

--- a/train_args.py
+++ b/train_args.py
@@ -563,6 +563,10 @@ def parse_args():
     logging_group.add_argument('--tensorboard_log', default=True, action=argparse.BooleanOptionalAction)
     logging_group.add_argument('--tensorboard_log_dir', type=str, default='logs')
     logging_group.add_argument('--tensorboard_run_name', type=str, default='logs-test')
+    logging_group.add_argument('--tensorboard_graph', default=True, action=argparse.BooleanOptionalAction)
+
+    # Onnx args
+    logging_group.add_argument('--onnx_output', default=False, action=argparse.BooleanOptionalAction)
 
     # Wandb args
     logging_group.add_argument('--wandb_log', default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
# Add Graph outputs of the models
Add netron and tensorboard graphs of the model.
The iteration these are exported is iteration 0.
I really like the tensorboard version, highly recommend trying it out.

## Examples
Tensorboard Example:
<img width="645" alt="image" src="https://github.com/user-attachments/assets/974d760c-54ce-4655-8d61-a028f7cd5dc7" />

Onnx (Netron) Example:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/1ccd9404-151c-440a-8732-d845ef38952c" />

View the above by grabbing the onnx file created in the out/ directory, and then using an app like netron.app to view.

## Usage

```sh
python3 train.py --tensorboard_graph --onnx_output
```