### PR TITLE
Added Support for ReLU Mistral and Llama Huggingface models

### DIFF
--- a/huggingface_model/llama_model.py
+++ b/huggingface_model/llama_model.py
@@ -1,0 +1,120 @@
+import torch
+import torch.nn as nn
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Import necessary functions from the LLaMA implementation.
+# Adjust the import paths if needed.
+from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb
+from transformers.models.llama.modeling_llama import eager_attention_forward  # reference version
+
+# Define our custom eager attention function that uses ReLU instead of softmax.
+def custom_eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor,
+    dropout: float,
+    scaling: float,
+    **kwargs,
+):
+    # Compute repeated keys/values if needed (the original version may use a helper; here we assume no change)
+    # Compute raw attention scores.
+    attn_scores = torch.matmul(query, key.transpose(-1, -2)) * scaling
+
+    if attention_mask is not None:
+        # The original code slices the attention_mask appropriately.
+        attn_scores = attn_scores + attention_mask
+
+    # Replace softmax with ReLU.
+    attn_weights = torch.relu(attn_scores)
+    # Manually normalize: sum over last dimension and divide.
+    attn_sum = attn_weights.sum(dim=-1, keepdim=True)
+    # Avoid division by zero.
+    attn_sum[attn_sum == 0] = 1.0
+    attn_weights = attn_weights / attn_sum
+
+    # Apply dropout.
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    # Compute the attention output.
+    attn_output = torch.matmul(attn_weights, value)
+    # In the original, attention output is transposed and contiguously reshaped by the caller.
+    return attn_output, attn_weights
+
+# Subclass LlamaAttention to override its forward behavior.
+class CustomLlamaAttention(LlamaAttention):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple,
+        attention_mask: torch.Tensor,
+        past_key_value=None,
+        cache_position=None,
+        **kwargs,
+    ):
+        # Save the input shape.
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        # Project hidden states to query, key, and value.
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        # Unpack rotary embeddings and apply them.
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if past_key_value is not None:
+            # Update key and value states if caching is used.
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+        # Instead of using the default attention_interface, we use our custom one.
+        attn_output, attn_weights = custom_eager_attention_forward(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            **kwargs,
+        )
+
+        # Reshape output back to the original hidden state shape.
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+def replace_llama_attention(model: AutoModelForCausalLM):
+    """
+    Traverse the model's decoder layers and replace each LlamaAttention module in self_attn
+    with our CustomLlamaAttention.
+    """
+    for i, layer in enumerate(model.model.layers):
+        orig_attn = layer.self_attn
+        # Instantiate our custom attention module with the same configuration.
+        custom_attn = CustomLlamaAttention(orig_attn.config)
+        # Copy weights from the original attention module.
+        custom_attn.load_state_dict(orig_attn.state_dict())
+        # Replace the attention module.
+        layer.self_attn = custom_attn
+        print(f"Replaced self_attn in layer {i} with CustomLlamaAttention.")
+
+# --- Usage Example ---
+model_name = "llama-7B"
+model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16)
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+# Replace attention modules with the custom version.
+replace_llama_attention(model)
+
+# Run a test forward pass to verify.
+input_text = "This is a test input to verify custom ReLU attention."
+inputs = tokenizer(input_text, return_tensors="pt").to(model.device)
+model.eval()
+with torch.no_grad():
+    outputs = model(**inputs)
+
+print("Forward pass completed. Check the console for any debug prints if added in custom attention.")

--- a/huggingface_model/llama_train.py
+++ b/huggingface_model/llama_train.py
@@ -1,0 +1,63 @@
+import torch
+import torch.nn as nn
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+)
+from datasets import load_dataset
+import llama_model
+
+# 4. Prepare a dataset for language modeling.
+# Here we use wikitext-2 for demonstration. In practice, use your target dataset.
+dataset = load_dataset("wikitext", "wikitext-2-raw-v1")
+
+# Add a new pad token
+llama_model.tokenizer.add_special_tokens({'pad_token': '[PAD]'})
+llama_model.model.resize_token_embeddings(len(llama_model.tokenizer))
+
+print(llama_model.model.config)
+
+# Concatenate the text of the train split.
+def preprocess_function(examples):
+    # Concatenate all texts.
+    return llama_model.tokenizer(examples["text"], truncation=True, max_length=512)
+
+tokenized_datasets = dataset.map(preprocess_function, batched=True, remove_columns=["text"])
+
+# Use a data collator that will dynamically pad the inputs.
+data_collator = DataCollatorForLanguageModeling(tokenizer=llama_model.tokenizer, mlm=False)
+
+# 5. Set up the training arguments.
+training_args = TrainingArguments(
+    output_dir="./llama_custom_finetune",
+    overwrite_output_dir=True,
+    num_train_epochs=1,           # Adjust the number of epochs.
+    per_device_train_batch_size=4,  # Adjust based on your GPU memory.
+    per_device_eval_batch_size=4,
+    evaluation_strategy="steps",
+    save_steps=500,
+    eval_steps=500,
+    logging_steps=100,
+    learning_rate=1e-5,
+    weight_decay=0.01,
+    fp16=True
+)
+
+# 6. Initialize the Trainer.
+trainer = Trainer(
+    model=llama_model.model,
+    args=training_args,
+    train_dataset=tokenized_datasets["train"],
+    eval_dataset=tokenized_datasets["validation"],
+    data_collator=data_collator,
+)
+
+# 7. Fine-tune the model.
+trainer.train()
+
+# 8. Save the finetuned model.
+llama_model.model.save_pretrained("llama_custom_finetuned")
+llama_model.tokenizer.save_pretrained("llama_custom_finetuned")

--- a/huggingface_model/mistral_model.py
+++ b/huggingface_model/mistral_model.py
@@ -1,0 +1,62 @@
+import torch
+import torch.nn as nn
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Import the original eager attention function from Mistral's modeling file.
+# Adjust the import path if needed.
+from transformers.models.mistral import modeling_mistral as mistral_mod
+
+# 1. Define a custom attention function that uses ReLU instead of softmax.
+def custom_eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor,
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs,
+):
+    # Repeat keys and values if needed (same as original)
+    key_states = mistral_mod.repeat_kv(key, module.num_key_value_groups)
+    value_states = mistral_mod.repeat_kv(value, module.num_key_value_groups)
+
+    # Compute raw attention scores and apply scaling.
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        # Here we assume attention_mask is already of proper shape (or we use slicing as in original)
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    # **Replace softmax with ReLU**
+    attn_weights = torch.relu(attn_weights)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    
+    # Compute attention output.
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, attn_weights
+
+# 2. Monkey-patch the eager_attention_forward function in Mistral's module.
+mistral_mod.eager_attention_forward = custom_eager_attention_forward
+print("Replaced Mistral's eager_attention_forward with custom version using ReLU.")
+
+# 3. Force the configuration to use "eager" attention implementation.
+# This ensures that the forward method in MistralAttention calls our custom function.
+model_name = "mistralai/Mistral-7B-v0.1"
+model = AutoModelForCausalLM.from_pretrained(
+    model_name, trust_remote_code=True, torch_dtype=torch.float16
+)
+model.config._attn_implementation = "eager"  # Ensure the eager path is used.
+tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+
+# 4. Run a small forward pass to test.
+input_text = "This is a test input for the custom attention."
+inputs = tokenizer(input_text, return_tensors="pt").to(model.device)
+model.eval()
+with torch.no_grad():
+    outputs = model(**inputs)
+
+print(model)
+
+print("Forward pass completed. Custom ReLU attention should have been used.")

--- a/huggingface_model/mistral_train.py
+++ b/huggingface_model/mistral_train.py
@@ -1,0 +1,62 @@
+import torch
+import torch.nn as nn
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+)
+from datasets import load_dataset
+import mistral_model
+
+# 4. Prepare a dataset for language modeling.
+# Here we use wikitext-2 for demonstration. In practice, use your target dataset.
+dataset = load_dataset("wikitext", "wikitext-2-raw-v1")
+
+# Add a new pad token
+mistral_model.tokenizer.add_special_tokens({'pad_token': '[PAD]'})
+mistral_model.model.resize_token_embeddings(len(mistral_model.tokenizer))
+
+print(mistral_model.model.config)
+
+# Concatenate the text of the train split.
+def preprocess_function(examples):
+    # Concatenate all texts.
+    return mistral_model.tokenizer(examples["text"], truncation=True, max_length=512)
+
+tokenized_datasets = dataset.map(preprocess_function, batched=True, remove_columns=["text"])
+
+# Use a data collator that will dynamically pad the inputs.
+data_collator = DataCollatorForLanguageModeling(tokenizer=mistral_model.tokenizer, mlm=False)
+
+# 5. Set up the training arguments.
+training_args = TrainingArguments(
+    output_dir="./mistral_custom_finetune",
+    overwrite_output_dir=True,
+    num_train_epochs=1,           # Adjust the number of epochs.
+    per_device_train_batch_size=4,  # Adjust based on your GPU memory.
+    per_device_eval_batch_size=4,
+    evaluation_strategy="steps",
+    save_steps=500,
+    eval_steps=500,
+    logging_steps=100,
+    learning_rate=5e-6,
+    weight_decay=0.01,
+)
+
+# 6. Initialize the Trainer.
+trainer = Trainer(
+    model=mistral_model.model,
+    args=training_args,
+    train_dataset=tokenized_datasets["train"],
+    eval_dataset=tokenized_datasets["validation"],
+    data_collator=data_collator,
+)
+
+# 7. Fine-tune the model.
+trainer.train()
+
+# 8. Save the finetuned model.
+mistral_model.model.save_pretrained("mistral_custom_finetuned")
+mistral_model.tokenizer.save_pretrained("mistral_custom_finetuned")


### PR DESCRIPTION
Similar to the gpt_train.py and gpt_model.py files, these allow for Huggingface Mistral and Llama models with customizable attention implementations. 

To run, simply call `python3 mistral_train.py` in the huggingface_models folder, which will invoke the ReLU attention Mistral model (with pre-trained weights) from mistral_model.py and fine-tune it on Wikitext103. 