### PR TITLE
New Attention variant - SSM (Adopted from Mamba and Hymba)

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -73,6 +73,13 @@ class GPTConfig:
     # Attention Options
     attention_variant: str = "causal"
 
+    ## SSM - Attention Varient (same as Hymba)
+    ssm_mamba_expand: int = 2
+    ssm_conv_kernel_size: int = 3
+    ssm_dt_rank: int = 8
+    ssm_d_state: int = 16
+    ssm_io_bias: bool = True
+
     # MLP Options
     use_parallel_mlp: bool = False
     mlp_variant: str = "mlp"

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -10,8 +10,3 @@ tiktoken==0.7.0
 torchinfo==1.8.0
 transformers==4.44.2
 wandb==0.18.3
-einops==0.8.1
-mamba-ssm==2.2.4
-setuptools==75.8.0
-ninja==1.11.1.3
-causal-conv1d==1.5.0.post8

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -10,5 +10,5 @@ tiktoken==0.7.0
 torchinfo==1.8.0
 transformers==4.44.2
 wandb==0.18.3
-torch==2.6.0
+torch==2.6.0+cpu
 causal-conv1d==1.5.0.post8

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -10,3 +10,5 @@ tiktoken==0.7.0
 torchinfo==1.8.0
 transformers==4.44.2
 wandb==0.18.3
+torch==2.6.0
+causal-conv1d==1.5.0.post8

--- a/train_args.py
+++ b/train_args.py
@@ -275,10 +275,16 @@ def parse_args():
         "--attention_variant",
         type=str,
         default="causal",
-        choices=["causal", "linear"],
+        choices=["causal", "linear", "ssm"],
         help="Which attention variant to use for the Transformer blocks."
     )
 
+    ## SSM - Attention Varient (same as Hymba)
+    model_group.add_argument("--ssm_mamba_expand",   type=int,  default=2)
+    model_group.add_argument("--ssm_conv_kernel_size",   type=int,  default=3)
+    model_group.add_argument("--ssm_dt_rank",   type=int,  default=8)
+    model_group.add_argument("--ssm_d_state",   type=int,  default=16)
+    model_group.add_argument("--ssm_io_bias",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="adds biases for nn.linear() of both in_proj and out_proj")
 
     # LINEAR VARIATIONS
     linear_variants = ["linear", "bitlinear", "bitlinear_1p58", "bitlinear_optimized", "kan","quantized_linear"]

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -9,6 +9,9 @@ from quantization.quantize import fake_quantize_act
 from quantization.quant_utils import set_variant, create_activation_buffers
 from variations.softmax_variations import softmax_dictionary
 from variations.position_encoding_variations import QuantizedEmbedding, RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
+from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
+
+from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
 
 class CausalSelfAttention(nn.Module):
     def __init__(self, config, fire_pos_enc=None):
@@ -387,7 +390,144 @@ class LinearAttention(nn.Module):
 
         return y
 
+class HymbaRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        HymbaRMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+class MambaBlock(nn.Module):
+    """ This function contains code adapted from [Hymba](https://github.com/NVlabs/hymba/) 
+    by the NVIDIA team, licensed under the [NVIDIA Open Model License Agreement]
+    (https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/).
+    """  
+    def __init__(self, config):
+        super().__init__()
+
+        self.d_model = config.n_embd
+        self.d_inner = self.d_model * config.ssm_mamba_expand
+        self.conv_kernel_size = config.ssm_conv_kernel_size
+        self.dt_rank = config.ssm_dt_rank
+        self.d_state = config.ssm_d_state
+        self.io_bias = config.ssm_io_bias
+
+        self.conv1d = nn.Conv1d(
+            in_channels=self.d_inner,
+            out_channels=self.d_inner,
+            bias=True,
+            kernel_size=self.conv_kernel_size,
+            groups=self.d_inner,
+            padding=self.conv_kernel_size - 1
+        )       
+
+        num_ssm_param = 1
+        self.in_proj = nn.ModuleList([nn.Linear(self.d_model, self.d_inner * 2, bias=self.iobias)])
+        self.x_proj = nn.ModuleList([nn.Linear(self.d_inner, self.dt_rank + self.d_state * 2, bias=False) for _ in range(num_ssm_param)])
+        self.dt_proj = nn.ModuleList([nn.Linear(self.dt_rank, self.d_inner, bias=True) for _ in range(num_ssm_param)])
+        self.out_proj = nn.ModuleList([nn.Linear(self.d_inner, self.d_model, bias=self.iobias)])
+
+        A = torch.arange(1, self.d_state + 1, dtype=torch.float32)[None, :]
+        A = A.expand(self.d_inner, -1).contiguous()
+        self.A_log = nn.ParameterList([nn.Parameter(torch.log(A)) for _ in range(num_ssm_param)])
+
+        self.D = nn.ParameterList([nn.Parameter(torch.ones(self.d_inner)) for _ in range(num_ssm_param)])
+
+        self.dt_layernorm = HymbaRMSNorm(self.dt_rank, eps=1e-06)
+        self.B_layernorm = HymbaRMSNorm(self.d_state, eps=1e-06)
+        self.C_layernorm = HymbaRMSNorm(self.d_state, eps=1e-06)
+        self.scan_outputs_layernorm = HymbaRMSNorm(self.d_inner)
+    
+    def _apply_layernorms(self, dt, B, C):
+        if self.dt_layernorm is not None:
+            dt = self.dt_layernorm(dt)
+        if self.B_layernorm is not None:
+            B = self.B_layernorm(B)
+        if self.C_layernorm is not None:
+            C = self.C_layernorm(C)
+        return dt, B, C
+
+    def forward(self, x, gate):
+        '''
+        Parameters:
+            x: (batch_size, seqlen, d_model)
+        Return:
+            scan_outputs: (batch_size, seqlen, d_model)
+
+        # d_model == n_embd (in attention)
+        # d_inner == d_model * mamba_expand
+
+        # conv1d.weight: (d_inner, 1, conv_kernel_size)
+        # conv_weights: (d_inner, conv_kernel_size)
+        # hidden_states: (batch_size, d_inner, seqlen)
+        # gate: (batch_size, d_inner, seqlen)
+        # delta: (batch_size, seqlen, dt_rank)
+        # discrete_delta: (batch, d_inner, seqlen)
+        # A: (d_inner, d_state)
+        # B: (batch_size, seqlen, d_state) before transpose(1,2)
+        # C: (batch_size, seqlen, d_state) before transpose(1,2)
+        '''
+        # we only have a single mamba head at this point
+        index = 0
+
+        projected_states = self.in_proj[index](x).transpose(1,2)
+
+        hidden_states, gate = projected_states.tensor_split((self.d_inner,), dim=1)
+
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
+        hidden_states = causal_conv1d_fn(
+            hidden_states, conv_weights, self.conv1d.bias, activation="silu"
+        )
+        
+        ssm_parameters = self.x_proj[index](hidden_states.transpose(1, 2))
+        delta, B, C = torch.split(ssm_parameters, [self.dt_rank, self.d_state, self.d_state], dim=-1)
+        delta, B, C = self._apply_layernorms(delta, B, C)
+        dt_proj_bias = self.dt_proj[index].bias
+        self.dt_proj[index].bias = None
+        discrete_delta = self.dt_proj[index](delta).transpose(1, 2)  # (batch_size, d_inner, seqlen)
+        self.dt_proj[index].bias = dt_proj_bias
+
+        A = -torch.exp(self.A_log[index].float())
+
+        dt_proj_bias = dt_proj_bias.float() if dt_proj_bias is not None else None
+
+        # mammba kernel from mamba_ssm
+        outputs = selective_scan_fn(
+            hidden_states,                          # (batch_size, d_inner, seqlen)
+            discrete_delta,
+            A,
+            B.transpose(1, 2),
+            C.transpose(1, 2),
+            self.D[index].float(),
+            z=gate,
+            delta_bias=dt_proj_bias,
+            delta_softplus=True,
+            return_last_state=True,
+        )                                           # (batch_size, d_inner, seqlen)
+        
+        if len(outputs) == 3:
+            scan_outputs, _, _ = outputs            # scan_outputs, ssm_state, last_state
+                                                    # ssm_state are updated inplace
+        else:
+            scan_outputs, _ = outputs
+
+        scan_outputs = scan_outputs.transpose(1, 2)  # (batch_size, seqlen, d_inner)
+        scan_outputs = self.scan_outputs_layernorm(scan_outputs)
+
+        output = self.out_proj[index](scan_outputs)
+        return output
+
 attention_dictionary = {
     "causal": CausalSelfAttention,
     "linear": LinearAttention,
+    "ssm": MambaBlock,
 }

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -9,9 +9,11 @@ from quantization.quantize import fake_quantize_act
 from quantization.quant_utils import set_variant, create_activation_buffers
 from variations.softmax_variations import softmax_dictionary
 from variations.position_encoding_variations import QuantizedEmbedding, RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
-from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
-from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
+# Mamba related imports
+if torch.cuda.is_available():
+    from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
+    from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
 
 class CausalSelfAttention(nn.Module):
     def __init__(self, config, fire_pos_enc=None):

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -411,11 +411,11 @@ class MambaBlock(nn.Module):
     by the NVIDIA team, licensed under the [NVIDIA Open Model License Agreement]
     (https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/).
     """  
-    def __init__(self, config):
+    def __init__(self, config, fire_pos_enc=None):
         super().__init__()
 
         self.d_model = config.n_embd
-        self.d_inner = self.d_model * config.ssm_mamba_expand
+        self.d_inner = int(self.d_model * config.ssm_mamba_expand)
         self.conv_kernel_size = config.ssm_conv_kernel_size
         self.dt_rank = config.ssm_dt_rank
         self.d_state = config.ssm_d_state
@@ -431,10 +431,10 @@ class MambaBlock(nn.Module):
         )       
 
         num_ssm_param = 1
-        self.in_proj = nn.ModuleList([nn.Linear(self.d_model, self.d_inner * 2, bias=self.iobias)])
+        self.in_proj = nn.ModuleList([nn.Linear(self.d_model, self.d_inner * 2, bias=self.io_bias)])
         self.x_proj = nn.ModuleList([nn.Linear(self.d_inner, self.dt_rank + self.d_state * 2, bias=False) for _ in range(num_ssm_param)])
         self.dt_proj = nn.ModuleList([nn.Linear(self.dt_rank, self.d_inner, bias=True) for _ in range(num_ssm_param)])
-        self.out_proj = nn.ModuleList([nn.Linear(self.d_inner, self.d_model, bias=self.iobias)])
+        self.out_proj = nn.ModuleList([nn.Linear(self.d_inner, self.d_model, bias=self.io_bias)])
 
         A = torch.arange(1, self.d_state + 1, dtype=torch.float32)[None, :]
         A = A.expand(self.d_inner, -1).contiguous()


### PR DESCRIPTION
## New Attention Variant - SSM

We support one more command option `--attention_variant="ssm"`.

## TODO
- [ ] Adding a hyperparameter list for selection of different attention variants (i.e. "causal", "linear" or "ssm") for different layers. 

## Training Results

You can replicate the following training results by running commands:
```
python3 train.py --compile
python3 train.py --compile --attention_variant="ssm"
```

### Comparison between `--attention_variant="causal"` and `--attention_variant="ssm"`
![image](https://github.com/user-attachments/assets/4599f7c8-f8c1-46a2-aff3-12b84b3ed571)
![image](https://github.com/user-attachments/assets/bf42271f-bbf4-4ec8-ab66-2b1e49cfa017)
![image](https://github.com/user-attachments/assets/f8ffb7e6-270b-45b5-a750-31bfd281b97b)

`--attention_variant="causal"`  step 0: train loss 4.2484, train_stdev 0.0031, val loss 4.2482, val_stdev 0.0031, lr 0.0010
`--attention_variant="ssm"`  step 0: train loss 4.3725, train_stdev 0.0045, val loss 4.3620, val_stdev 0.0048, lr 0.0010
![image](https://github.com/user-attachments/assets/4f5e8eff-6f80-4786-aa32-457c741c6ba0)

