### PR TITLE
Add Infinite Head Attention Variant

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -12,6 +12,9 @@ class GPTConfig:
     n_kv_group: int = 12
     n_embd: int = 768
 
+    # Attention Variation Spedcific
+    n_head_dim: int = None # For Infinite Attention variation
+
     # Steering Vectors
     ## Where to intercept
     apply_vector_at_layer_idx: int = None

--- a/train_args.py
+++ b/train_args.py
@@ -275,9 +275,12 @@ def parse_args():
         "--attention_variant",
         type=str,
         default="causal",
-        choices=["causal", "linear", "ssm"],
+        choices=["causal", "linear", "ssm", "infinite"],
         help="Which attention variant to use for the Transformer blocks."
     )
+
+    # Inifinite Attention variation
+    model_group.add_argument('--n_head_dim', default=None, type=int)
 
     ## SSM - Attention Varient (same as Hymba)
     model_group.add_argument("--ssm_mamba_expand",   type=int,  default=2)

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -409,10 +409,10 @@ class HymbaRMSNorm(nn.Module):
         return self.weight * hidden_states.to(input_dtype)
 
 class MambaBlock(nn.Module):
-    """ This function contains code adapted from [Hymba](https://github.com/NVlabs/hymba/) 
+    """ This function contains code adapted from [Hymba](https://github.com/NVlabs/hymba/)
     by the NVIDIA team, licensed under the [NVIDIA Open Model License Agreement]
     (https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/).
-    """  
+    """
     def __init__(self, config, fire_pos_enc=None):
         super().__init__()
 
@@ -430,7 +430,7 @@ class MambaBlock(nn.Module):
             kernel_size=self.conv_kernel_size,
             groups=self.d_inner,
             padding=self.conv_kernel_size - 1
-        )       
+        )
 
         num_ssm_param = 1
         self.in_proj = nn.ModuleList([nn.Linear(self.d_model, self.d_inner * 2, bias=self.io_bias)])
@@ -448,7 +448,7 @@ class MambaBlock(nn.Module):
         self.B_layernorm = HymbaRMSNorm(self.d_state, eps=1e-06)
         self.C_layernorm = HymbaRMSNorm(self.d_state, eps=1e-06)
         self.scan_outputs_layernorm = HymbaRMSNorm(self.d_inner)
-    
+
     def _apply_layernorms(self, dt, B, C):
         if self.dt_layernorm is not None:
             dt = self.dt_layernorm(dt)
@@ -489,7 +489,7 @@ class MambaBlock(nn.Module):
         hidden_states = causal_conv1d_fn(
             hidden_states, conv_weights, self.conv1d.bias, activation="silu"
         )
-        
+
         ssm_parameters = self.x_proj[index](hidden_states.transpose(1, 2))
         delta, B, C = torch.split(ssm_parameters, [self.dt_rank, self.d_state, self.d_state], dim=-1)
         delta, B, C = self._apply_layernorms(delta, B, C)
@@ -515,7 +515,7 @@ class MambaBlock(nn.Module):
             delta_softplus=True,
             return_last_state=True,
         )                                           # (batch_size, d_inner, seqlen)
-        
+
         if len(outputs) == 3:
             scan_outputs, _, _ = outputs            # scan_outputs, ssm_state, last_state
                                                     # ssm_state are updated inplace
@@ -528,8 +528,101 @@ class MambaBlock(nn.Module):
         output = self.out_proj[index](scan_outputs)
         return output
 
+class InfiniteHeadAttention(nn.Module):
+    """Instead of concatenating heads, utilizing higher capacity, we assume the
+    vector features are independent of each other, and simply add the values.
+
+    This removes the constraint of having number_of_heads % embed_dim = 0, resulting in:
+      * a) removes the limit on the number of heads (before increasing heads too much leads to reduced emb_dim per head, and head utility)
+      * b) from a), this means we can keep adding heads until the model saturates the vector.
+      * c) while all heads need to be the same size, we have new param exploration, number of heads and the dimension per head.
+      * d) we can potentially even try removing the c_proj, if the embedding dimension chosen is the same as that of the model
+      * e) since the MLP/MoE has the majority of parameters, this may benefit
+             parameter efficiency by allowing more relations to be encoded into the
+             residual per attention layer.
+      * f) for smaller models, we can increase the embedding dim per head, to
+             match that of high quality 1024 and higher embedding heads, which has
+             been noted to be a bottleneck when digesting large trees of information
+             in a single layer e.g. multidigit addition.
+    """
+    def __init__(self, config, fire_pos_enc=None):
+        super().__init__()
+
+        self.n_head = config.n_head
+        self.n_head_dim = config.n_head_dim
+        self.n_embd = config.n_embd
+
+        self.linear_variant_q = linear_dictionary[config.linear_variant_attn]
+        self.linear_variant_k = linear_dictionary[config.linear_variant_attn]
+        self.linear_variant_v = linear_dictionary[config.linear_variant_attn]
+        self.linear_variant_attn_proj = linear_dictionary[config.linear_variant_attn]
+
+        # TODO: no reason for qk and v to have same dimension
+        self.c_attn_q = self.linear_variant_q(self.n_embd, self.n_head * self.n_head_dim, config, bias=config.bias)
+        self.c_attn_k = self.linear_variant_k(self.n_embd, self.n_head * self.n_head_dim, config, bias=config.bias)
+        self.c_attn_v = self.linear_variant_v(self.n_embd, self.n_head * self.n_head_dim, config, bias=config.bias)
+        self.c_proj = self.linear_variant_attn_proj(self.n_head_dim, self.n_embd, config, bias=config.bias)
+
+        # Regularization
+        self.attn_dropout = nn.Dropout(config.dropout)
+        self.resid_dropout = nn.Dropout(config.dropout)
+        self.dropout = config.dropout
+
+        # Embedding
+        self.n_embd = config.n_embd
+        self.dropout = config.dropout
+
+        # Rotary Positional Embeddings
+        self.rotary_emb_q = None
+        self.rotary_emb_k = None
+
+        # Softmax Variant Selection
+        self.softmax_variant_attn = config.softmax_variant_attn
+        if self.softmax_variant_attn != 'softmax':
+            self.softmax_layer_attn = softmax_dictionary[config.softmax_variant_attn](config)
+
+        self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
+                             .view(1, 1, config.block_size, config.block_size))
+
+    def forward(self, x, iter_num):
+        B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
+
+        q = self.c_attn_q(x)
+        k = self.c_attn_k(x)
+        v = self.c_attn_v(x)
+
+        q = q.view(B, T, self.n_head, self.n_head_dim).transpose(1, 2) # (B, n_h, T, hs)
+        k = k.view(B, T, self.n_head, self.n_head_dim).transpose(1, 2) # (B, n_kv, T, hs)
+        v = v.view(B, T, self.n_head, self.n_head_dim).transpose(1, 2) # (B, n_kv, T, hs)
+
+        y = None
+        att = None
+        # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
+        # manual implementation of attention
+        att = (q @ k.transpose(-2, -1)) * (1.0 / torch.sqrt(torch.tensor([k.size(-1)], dtype=q.dtype, device=q.device)))
+
+        # apply lower triangle attention mask
+        att = att.masked_fill(self.bias[:,:,:T,:T].to(x.device) == 0, float('-inf'))
+
+        # softmax variation
+        if self.softmax_variant_attn != 'softmax':
+            att = self.softmax_layer_attn(att)
+        else:
+            att = F.softmax(att, dim=-1)
+
+        att = self.attn_dropout(att)
+
+        y = (att @ v).sum(dim=1)  # Sum over all heads instead of concatenation
+
+        # output projection
+        y = self.resid_dropout(self.c_proj(y))
+
+        return y
+
+
 attention_dictionary = {
     "causal": CausalSelfAttention,
     "linear": LinearAttention,
     "ssm": MambaBlock,
+    "infinite": InfiniteHeadAttention,
 }


### PR DESCRIPTION
This is a variation of causal self attention that adds the results of each head (taking a page from JLS Lemma on capacity), and has potential to improve parameter efficiency -- with particular boost for smaller models where the head dimension required to be even smaller than the embedding dimension.

This limit is removed by this variation, and since most transformers are limited not by the attention by the MLP, allows exploring how we can potentially do more parallel computation and limit the size, by reducing the number of layers required to supply the necessary tooken inter-relations.