### PR TITLE
Add token counts to tokenizers

### DIFF
--- a/data/template/prepare.py
+++ b/data/template/prepare.py
@@ -1,3 +1,4 @@
+# prepare.py
 import json
 import os
 import argparse
@@ -41,6 +42,8 @@ def parse_arguments():
     parser.add_argument("--numeric_range", action="store_true", help="Use numeric range tokenization method")
     parser.add_argument("--min_token", type=int, default=0, help="Minimum value for numeric tokens")
     parser.add_argument("--max_token", type=int, default=65535, help="Maximum value for numeric tokens")
+    # tokenizer counts
+    parser.add_argument("--track_token_counts", action="store_true", help="Track how often each token appears and store in meta.pkl")
     return parser.parse_args()
 
 

--- a/data/template/tests.py
+++ b/data/template/tests.py
@@ -2,7 +2,8 @@
 
 import unittest
 import os
-import sys  # Import sys to exit with error codes
+import sys
+import pickle
 from tokenizers import (
     NumericRangeTokenizer,
     SentencePieceTokenizer,
@@ -15,7 +16,6 @@ from argparse import Namespace
 from rich.console import Console
 from rich.theme import Theme
 from rich.table import Table
-from rich.text import Text
 
 console = Console(theme=Theme({
     "pass": "bold green",
@@ -26,7 +26,6 @@ console = Console(theme=Theme({
     "output": "bold magenta",
     "info": "bold blue",
 }))
-
 
 class RichTestResult(unittest.TestResult):
     def __init__(self):
@@ -70,12 +69,10 @@ def run_tests():
     table.add_column("Result", justify="center")
     for test, status in result.test_results:
         test_name = test._testMethodName
-        if status == 'PASS':
-            style = "pass"
-        else:
-            style = "fail"
+        style = "pass" if status == 'PASS' else "fail"
         table.add_row(test_name, f"[{style}]{status}[/{style}]")
     console.print(table)
+
     # Exit with error code if any test failed
     if not result.wasSuccessful():
         sys.exit(1)  # Exit with status code 1 if tests failed
@@ -110,6 +107,39 @@ class TestTokenizers(unittest.TestCase):
         if os.path.exists("remaining.txt"):
             os.remove("remaining.txt")
 
+    # --------------------------------------------------------------------------
+    # Helper Method to Print Token Count Histogram
+    # --------------------------------------------------------------------------
+    def _print_token_count_histogram(self, token_counts, itos):
+        """
+        Prints a histogram of all tokens in `token_counts`, sorted by descending frequency.
+        Columns: Token ID, Actual Token, Count, Bar
+        """
+
+        if not token_counts:
+            console.print("[info]No token counts to display.[/info]")
+            return
+
+        console.print("[info]Token Count Histogram (All Tokens):[/info]")
+        table = Table("Token ID", "Token", "Count", "Bar", title="Histogram")
+
+        # Sort all tokens in descending order by count
+        sorted_counts = sorted(token_counts.items(), key=lambda x: x[1], reverse=True)
+        max_count = max(token_counts.values())
+
+        for token_id, count in sorted_counts:
+            token_str = itos.get(token_id, f"<UNK:{token_id}>")
+            bar_len = 20  # max width in characters
+            filled = int((count / max_count) * bar_len)
+            bar_str = "█" * filled
+            table.add_row(str(token_id), repr(token_str), str(count), bar_str)
+
+        console.print(table)
+        console.print()  # extra newline
+
+    # --------------------------------------------------------------------------
+    # Tokenizer Tests
+    # --------------------------------------------------------------------------
     def test_numeric_range_tokenizer(self):
         args = Namespace(min_token=100, max_token=1000)
         tokenizer = NumericRangeTokenizer(args)
@@ -192,7 +222,7 @@ class TestTokenizers(unittest.TestCase):
             f.write('a\nb\nc\n\\n')
 
         tokenizer = CustomCharTokenizerWithByteFallback(args)
-        test_string = 'abc😊d\nefg'
+        test_string = "abc😊😊dd\nefg"
 
         ids = tokenizer.tokenize(test_string)
         detokenized = tokenizer.detokenize(ids)
@@ -203,20 +233,172 @@ class TestTokenizers(unittest.TestCase):
         console.print(detokenized, style="output")
 
         console.print("[info]Characters that used byte fallback:[/info]")
-        bft = [] # Byte Fallback Tokens
+        bft = []
         for char in detokenized:
-            if char not in tokenizer.custom_chars:
-                char = repr(char)
-                bft.append(char)
+            # If it's not in the custom tokens, we consider it fallback
+            if char not in tokenizer.custom_tokens:
+                bft.append(repr(char))
 
         console.print(", ".join(bft), style="info")
 
         self.assertEqual(test_string, detokenized)
-        print("CustomCharTokenizerWithByteFallback test passed.")
+        console.print("CustomCharTokenizerWithByteFallback test passed.")
 
         # Clean up
         if os.path.exists(args.custom_chars_file):
             os.remove(args.custom_chars_file)
+
+
+    # --------------------------------------------------------------------------
+    # Tests for Token Counts (with histogram printing)
+    # --------------------------------------------------------------------------
+    def test_numeric_range_tokenizer_counts(self):
+        args = Namespace(min_token=100, max_token=1000, track_token_counts=True)
+        tokenizer = NumericRangeTokenizer(args)
+        ids = tokenizer.tokenize(self.numeric_data)
+
+        with open("meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        token_counts = meta.get("token_counts", {})
+
+        # Retrieve the itos mapping so we can display actual tokens in the histogram
+        itos = meta.get("itos", {})
+
+        # Print histogram
+        self._print_token_count_histogram(token_counts, itos)
+
+        self.assertEqual(
+            sum(token_counts.values()), 
+            len(ids),
+            "Total token counts should match number of tokens."
+        )
+        for token_id in ids:
+            self.assertIn(token_id, token_counts, 
+                          "Each token id should appear in token_counts.")
+
+    def test_sentencepiece_tokenizer_counts(self):
+        with open("spm_input.txt", "w") as f:
+            f.write(self.sample_text)
+
+        args = Namespace(
+            vocab_size=30,
+            spm_model_file=None,
+            spm_vocab_file=None,
+            skip_tokenization=False,
+            track_token_counts=True
+        )
+        tokenizer = SentencePieceTokenizer(args, input_files="spm_input.txt")
+        ids = tokenizer.tokenize(self.sample_text)
+
+        with open("meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        token_counts = meta.get("token_counts", {})
+
+        itos = meta.get("itos", {})
+
+        # Print histogram
+        self._print_token_count_histogram(token_counts, itos)
+
+        self.assertEqual(
+            sum(token_counts.values()), 
+            len(ids),
+            "Total token counts should match number of tokens for SentencePiece."
+        )
+        for token_id in ids:
+            self.assertIn(token_id, token_counts)
+
+    def test_tiktoken_tokenizer_counts(self):
+        args = Namespace(tiktoken_encoding='gpt2', track_token_counts=True)
+        tokenizer = TiktokenTokenizer(args)
+        ids = tokenizer.tokenize(self.sample_text)
+
+        with open("meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        token_counts = meta.get("token_counts", {})
+        itos = meta.get("itos", {})
+
+        # Print histogram
+        self._print_token_count_histogram(token_counts, itos)
+
+        self.assertEqual(
+            sum(token_counts.values()), 
+            len(ids),
+            "Total token counts should match for Tiktoken."
+        )
+        for token_id in ids:
+            self.assertIn(token_id, token_counts)
+
+    def test_custom_tokenizer_counts(self):
+        args = Namespace(tokens_file=self.tokens_file, track_token_counts=True)
+        tokenizer = CustomTokenizer(args)
+        ids = tokenizer.tokenize(self.sample_text)
+
+        with open("meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        token_counts = meta.get("token_counts", {})
+        itos = meta.get("itos", {})
+
+        # Print histogram
+        self._print_token_count_histogram(token_counts, itos)
+
+        self.assertEqual(
+            sum(token_counts.values()), 
+            len(ids),
+            "Total token counts should match for CustomTokenizer."
+        )
+        for token_id in ids:
+            self.assertIn(token_id, token_counts)
+
+    def test_char_tokenizer_counts(self):
+        args = Namespace(reuse_chars=False, track_token_counts=True)
+        tokenizer = CharTokenizer(args, self.sample_text, None)
+        ids = tokenizer.tokenize(self.sample_text)
+
+        with open("meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        token_counts = meta.get("token_counts", {})
+        itos = meta.get("itos", {})
+
+        # Print histogram
+        self._print_token_count_histogram(token_counts, itos)
+
+        self.assertEqual(
+            sum(token_counts.values()), 
+            len(ids),
+            "Total token counts should match for CharTokenizer."
+        )
+        for token_id in ids:
+            self.assertIn(token_id, token_counts)
+
+    def test_custom_char_tokenizer_with_byte_fallback_counts(self):
+        args = Namespace(custom_chars_file="custom_chars.txt", track_token_counts=True)
+        test_string = "abc😊😊dd\nefg"
+        with open(args.custom_chars_file, 'w', encoding='utf-8') as f:
+            f.write('a\nb\nc\n\\n')
+
+        tokenizer = CustomCharTokenizerWithByteFallback(args)
+        ids = tokenizer.tokenize(test_string)
+
+        with open("meta.pkl", "rb") as f:
+            meta = pickle.load(f)
+        token_counts = meta.get("token_counts", {})
+        itos = meta.get("itos", {})
+
+        # Print histogram
+        self._print_token_count_histogram(token_counts, itos)
+
+        self.assertEqual(
+            sum(token_counts.values()), 
+            len(ids),
+            "Total token counts should match for CustomCharTokenizerWithByteFallback."
+        )
+        for token_id in ids:
+            self.assertIn(token_id, token_counts)
+
+        # Clean up
+        if os.path.exists(args.custom_chars_file):
+            os.remove(args.custom_chars_file)
+
 
 if __name__ == '__main__':
     run_tests()

--- a/data/template/utils/meta_util.py
+++ b/data/template/utils/meta_util.py
@@ -1,11 +1,14 @@
+# meta_util.py
+
 import pickle
 import argparse
-
+from rich.console import Console
+from rich.theme import Theme
+from rich.table import Table
 
 def load_meta(file_path):
     with open(file_path, "rb") as f:
         return pickle.load(f)
-
 
 def view_tokens(meta_path):
     meta = load_meta(meta_path)
@@ -17,6 +20,39 @@ def view_tokens(meta_path):
     for k, v in list(meta["itos"].items())[:]:
         print(f"{k}: {v}")
 
+def visualize_histogram(meta_path, top_n=20):
+    """
+    Visualizes token frequencies (if present) in a meta.pkl as a bar chart.
+    Requires 'token_counts' to exist in the meta dictionary.
+    """
+    meta = load_meta(meta_path)
+    token_counts = meta.get("token_counts")
+    if not token_counts:
+        print("No 'token_counts' found in the meta. Cannot visualize histogram.")
+        return
+
+    console = Console(theme=Theme({"info": "bold blue"}))
+    console.print("[info]Histogram of Token Counts:[/info]")
+    table = Table("Token ID", "Token String", "Count", "Bar", title="Token Count Histogram")
+
+    # Sort tokens by descending frequency
+    sorted_counts = sorted(token_counts.items(), key=lambda x: x[1], reverse=True)
+    max_count = max(token_counts.values())
+
+    # If we have 'itos', we can display the actual token strings
+    itos = meta.get("itos", {})
+
+    # Print the top_n tokens (or all if you prefer)
+    for token_id, count in sorted_counts[:top_n]:
+        token_str = itos.get(token_id, f"<UNK:{token_id}>")
+        # Build a simple bar
+        bar_len = 20
+        filled = int((count / max_count) * bar_len)
+        bar_str = "█" * filled
+
+        table.add_row(str(token_id), repr(token_str), str(count), bar_str)
+
+    console.print(table)
 
 def merge_metas(meta_path1, meta_path2, output_path):
     meta1 = load_meta(meta_path1)
@@ -29,20 +65,15 @@ def merge_metas(meta_path1, meta_path2, output_path):
     # Update with tokens from the second meta, resolving conflicts by prioritizing the first meta
     for token, id in meta2["stoi"].items():
         if token not in stoi:
-            # If the token is not in stoi, add it
-            new_id = (
-                max(itos.keys()) + 1
-            )  # Assign a new ID that is the current max ID + 1
+            new_id = max(itos.keys()) + 1
             stoi[token] = new_id
             itos[new_id] = token
-        # If the token is already in stoi, it's skipped, thereby prioritizing meta1's mapping
 
     vocab_size = len(stoi)
     meta = {"vocab_size": vocab_size, "stoi": stoi, "itos": itos}
     with open(output_path, "wb") as f:
         pickle.dump(meta, f)
     print(f"Merged meta saved to {output_path}, prioritizing {meta_path1}.")
-
 
 def create_meta_from_text(text_file, output_path, special_chars={"<ukn>": 0}):
     with open(text_file, "r") as f:
@@ -69,29 +100,34 @@ def export_tokens(meta_path, output_path):
                 token = "\\t"
             elif token == "\r":
                 token = "\\r"
-            # Note: Add more special character handling here as needed
             f.write(token + "\n")
     print(f"Tokens exported to {output_path}")
-    
+
 def main():
     parser = argparse.ArgumentParser(description="Utility for handling token metadata.")
 
     parser.add_argument("--view", type=str, help="Path to the meta.pkl file to view.")
-
-    parser.add_argument(
-        "--merge", nargs=2, help="Paths to the two meta.pkl files to merge."
-    )
-
+    parser.add_argument("--merge", nargs=2, help="Paths to the two meta.pkl files to merge.")
     parser.add_argument(
         "--create",
         nargs=2,
         help="Path to the input text file and the output meta.pkl file for creation.",
     )
-    
     parser.add_argument(
         "--export",
         nargs=2,
         help="Path to the meta.pkl file and the output text file for exporting tokens.",
+    )
+    parser.add_argument(
+        "--hist",
+        type=str,
+        help="Path to the meta.pkl file for visualizing token frequency histogram.",
+    )
+    parser.add_argument(
+        "--hist-top",
+        type=int,
+        default=20,
+        help="(Optional) Number of top tokens to show in histogram. Defaults to 20.",
     )
 
     args = parser.parse_args()
@@ -104,6 +140,11 @@ def main():
         create_meta_from_text(args.create[0], args.create[1])
     elif args.export:
         export_tokens(args.export[0], args.export[1])
+    elif args.hist:
+        visualize_histogram(args.hist, args.hist_top)
+    else:
+        parser.print_help()
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
# Token Counts

This adds an implementation for counting tokens by ids and will allow better metrics when calculating the loss metrics vs random chance.

The tokenizer already has to token everything, so adding a count is relatively lightweight.

## Preview of Histogram

This is for shakespeare char with the char tokenization:

![image](https://github.com/user-attachments/assets/d90cf290-150d-4f2d-b419-65d7ce9e59e7)

## meta.pkl

The meta.pkl now has a record of the count, which can ultimately either adjust the loss per token (would need to import to model.py) or reported better than chance probability per token (modifying the train.py).

To enable this one needs to call:

```bash
python3 prepare.py --method char  -t input.txt --track_token_counts
```
