### PR TITLE
Fix one Bug in train.py when using DDP on multiple A100s

### DIFF
--- a/train.py
+++ b/train.py
@@ -301,7 +301,10 @@ class Trainer:
 
         # Tensorboard
         if self.args.tensorboard_log:
-            timestamped_run_name = f"{self.model.num_param:.2e}_{timestamp_prefix}_{self.args.tensorboard_run_name}"
+            if self.ddp:
+                timestamped_run_name = f"{self.model.module.num_param:.2e}_{timestamp_prefix}_{self.args.tensorboard_run_name}"
+            else:
+                timestamped_run_name = f"{self.model.num_param:.2e}_{timestamp_prefix}_{self.args.tensorboard_run_name}"
             if self.args.csv_log:
                 self.args.csv_name = timestamped_run_name
             log_subpath = os.path.join(self.args.tensorboard_log_dir, timestamped_run_name)


### PR DESCRIPTION
When running on 2 A100 GPUs, I found a bug like this: `[rank1]: AttributeError: 'DistributedDataParallel' object has no attribute 'num_param'`

It seems like the model is wrapped inside DistributedDataParallel (DDP), which is likely causing the issue where self.model.num_param is not accessible. This is because in DDP, the model is wrapped in a DistributedDataParallel wrapper, and its attributes might not be directly accessible from self.model. Instead, the model is nested inside the module attribute of DistributedDataParallel.

DistributedDataParallel(
  (module): OptimizedModule(
    (_orig_mod): GPT(
      (transformer): ModuleDict(
        (wte): Embedding(50257, 384)
        (drop): Dropout(p=0.0, inplace=False)
        (h): ModuleList(
          (0-19): 20 x Block(
            (ln_1): RMSNorm()
            (ln_2): RMSNorm()
            (attn): CausalSelfAttention(
              (c_attn_q): WrappedLinear(in_features=384, out_features=384, bias=False)
              (c_attn_k): WrappedLinear(in_features=384, out_features=384, bias=False)
              (c_attn_v): WrappedLinear(in_features=384, out_features=384, bias=False)
              (c_proj): WrappedLinear(in_features=384, out_features=384, bias=False)
              (attn_dropout): Dropout(p=0.0, inplace=False)
              (resid_dropout): Dropout(p=0.0, inplace=False)
              (softmax_layer_attn): ReLUMax(
                (relumax): ReLU()
              )
            )
            (mlp): OriginalMLP(
              (activation_variant): Softplus_Config(
                (activation): Softplus(beta=1.0, threshold=20.0)
              )
              (c_fc): WrappedLinear(in_features=384, out_features=1536, bias=False)
              (c_proj): WrappedLinear(in_features=1536, out_features=384, bias=False)
              (dropout): Dropout(p=0.0, inplace=False)
            )
          )
        )
        (ln_f): RMSNorm()
        (wpe): Embedding(256, 384)
      )
      (lm_head): Linear(in_features=384, out_features=50257, bias=False)
    )
  )
)