### PR TITLE
Add qk norm and exploration monitor

### DIFF
--- a/create_new_exploration.sh
+++ b/create_new_exploration.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# create_new_exploration.sh
+
+new_exploration_name="$1"
+
+cp ./explorations/sample.yaml "./explorations/${new_exploration_name}.yaml"

--- a/explorations/qk_norm.yaml
+++ b/explorations/qk_norm.yaml
@@ -1,0 +1,29 @@
+# qk_norm.yaml
+---
+# parameter_groups: define sets of overrides to apply on top of base params
+parameter_groups:
+  - use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [true]
+  - use_rotary_embeddings: [false]
+    use_abs_pos_embeddings: [true]
+  - use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+# base hyperparameters
+max_iters: [5000]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [256]
+device: ["cuda"]
+dtype: ["float16"]
+dataset: ["shakespeare_char"]
+
+use_qk_norm: [true, false]
+use_qk_norm_scale: [true, false]
+
+softmax_variant_attn:
+  - softmax
+  - strongermax
+
+compile: [true]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -106,8 +106,8 @@ class GPTConfig:
     attention_variant: str = "causal"
 
     # QK Norm Options
-    use_qk_norm: bool = "false"
-    use_qk_norm_scale: bool = "false"
+    use_qk_norm: bool = False
+    use_qk_norm_scale: bool = False
 
     ## SSM - Attention Varient (same as Hymba)
     ssm_mamba_expand: int = 2

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -105,6 +105,10 @@ class GPTConfig:
     # Attention Options
     attention_variant: str = "causal"
 
+    # QK Norm Options
+    use_qk_norm: bool = "false"
+    use_qk_norm_scale: bool = "false"
+
     ## SSM - Attention Varient (same as Hymba)
     ssm_mamba_expand: int = 2
     ssm_conv_kernel_size: int = 3

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -2,21 +2,37 @@
 """
 Textual app to monitor hyperparameter search results from a YAML log file.
 Refreshes every N seconds, showing all runs in a DataTable view.
-Press Enter on the selected cell to toggle sorting by that column; repeat to clear the sort.
-Use 'h'/'l' to move the selected column left/right, with cursor following.
-Press 'd' to hide the selected column, and 'o' to unhide all hidden columns.
-Preserves cursor position and header order across refreshes, fully expanding to fill vertical space.
-Only shows horizontal scrollbar if content overflows horizontally; vertical scrollbar appears only if content exceeds available height.
-Sorting is implemented via bubble sort to preserve stability and applies new sorts on currently displayed order.
+Interactive keybindings:
+  Enter - toggle sort by column
+  h/l   - move column left/right
+  d     - hide column
+  o     - unhide all columns
+  x     - hide all rows matching current cell in column
+  i     - invert filter: keep only rows matching current cell in column
+  O     - unhide all rows (clear row filters)
+  ?     - show help overlay
+  e     - export current view to CSV
+  s     - save current layout
+
+Preserves cursor position, header order, and applied row/column filters across refreshes.
+Fully expands to fill vertical space with scrollbars only when overflow.
+Sorting is a stable bubble sort applied to the current view order.
+Persistent layout and filters are stored in ~/.monitor_layout.json when 's' is pressed.
 """
 import argparse
+import csv
+import json
+import time
 import yaml
 from pathlib import Path
 from typing import Optional, List, Dict
 from textual.app import App, ComposeResult
 from textual import events
 from textual.containers import Container
-from textual.widgets import DataTable, Header, Footer
+from textual.screen import ModalScreen
+from textual.widgets import DataTable, Header, Footer, Static
+
+LAYOUT_FILE = Path.home() / ".monitor_layout.json"
 
 
 def load_runs(log_file: Path) -> List[Dict]:
@@ -30,20 +46,38 @@ def load_runs(log_file: Path) -> List[Dict]:
     return docs
 
 
+class HelpScreen(ModalScreen):
+    def compose(self) -> ComposeResult:
+        help_text = (
+            "Enter: toggle sort by column\n"
+            "h/l: move column left/right\n"
+            "d: hide column\n"
+            "o: unhide all columns\n"
+            "x: hide rows matching value\n"
+            "i: keep only rows matching value\n"
+            "O: clear all row filters\n"
+            "?: show this help\n"
+            "e: export CSV\n"
+            "s: save layout (columns, hidden-cols, filters)\n"
+            "Press any key to close."
+        )
+        yield Static(help_text, id="help_text")
+
+    async def on_key(self, event: events.Key) -> None:
+        await self.dismiss()
+
+
 class MonitorApp(App):
     CSS = """
-    Screen {
-        align: center middle;
-    }
-    Container {
-        height: 1fr;
-    }
+    Screen { align: center middle; }
+    Container { height: 1fr; }
     DataTable#table {
         height: 1fr;
         width: 1fr;
         overflow-x: auto;
         overflow-y: auto;
     }
+    #help_text { padding: 1; background: $surface; color: $text; border: heavy $primary; }
     """
 
     def __init__(self, log_file: Path, interval: float) -> None:
@@ -53,12 +87,12 @@ class MonitorApp(App):
         self.param_keys: List[str] = []
         self.columns: List[str] = []
         self.all_columns: List[str] = []
-        self.hidden: set[str] = set()
+        self.hidden_cols: set[str] = set()
         self.sort_column: Optional[int] = None
         self.sort_reverse: bool = False
         self.table: Optional[DataTable] = None
-        # Current displayed entries (maintains order across sorts)
-        self.current_entries: List[Dict] = []
+        self.original_entries: List[Dict] = []  # unfiltered data
+        self.current_entries: List[Dict] = []   # view data with row filters
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -69,89 +103,85 @@ class MonitorApp(App):
 
     def on_mount(self) -> None:
         self.table = self.query_one(DataTable)
-        # Load initial entries
-        self.current_entries = load_runs(self.log_file)
-        # Determine parameter columns
+        # Load all entries
+        self.original_entries = load_runs(self.log_file)
+        self.current_entries = list(self.original_entries)
+        # Determine columns from config keys
         keys = set()
-        for e in self.current_entries:
+        for e in self.original_entries:
             keys.update(e.get("config", {}).keys())
         self.param_keys = sorted(keys)
-
-        # Base column ordering
-        base = ["best_val_loss", "best_val_iter", "num_params"] + self.param_keys
-        self.columns = base.copy()
-        self.all_columns = base.copy()
-
-        # Initial table setup
+        base_cols = ["best_val_loss", "best_val_iter", "num_params"] + self.param_keys
+        self.all_columns = base_cols.copy()
+        self.columns = base_cols.copy()
+        # Load persisted layout
+        if LAYOUT_FILE.exists():
+            cfg = json.load(open(LAYOUT_FILE))
+            self.all_columns = cfg.get("all_columns", self.all_columns)
+            self.hidden_cols = set(cfg.get("hidden_cols", []))
+            self.columns = [c for c in self.all_columns if c not in self.hidden_cols]
+            self.sort_column = cfg.get("sort_column")
+            self.sort_reverse = cfg.get("sort_reverse", False)
+            # Row filters
+            self.current_entries = [e for e in self.original_entries]
+            row_filters = cfg.get("row_filters", [])
+            for filt in row_filters:
+                col, op, val = filt
+                if op == "hide":
+                    self.current_entries = [e for e in self.current_entries if str(self.get_cell(e,col)) != val]
+                elif op == "keep":
+                    self.current_entries = [e for e in self.current_entries if str(self.get_cell(e,col)) == val]
+        # Build and schedule
         self.build_table()
-
-        # Schedule refresh and load
         self.set_interval(self.interval, self.refresh_table)
         self.refresh_table()
 
     def build_table(self) -> None:
-        # Rebuild columns according to self.columns
         if not self.table:
             return
         self.table.clear(columns=True)
         for col in self.columns:
-            self.table.add_column(col, width=max(12, len(col) + 2))
+            self.table.add_column(col, width=max(12, len(col)+2))
+
+    def get_cell(self, entry: Dict, col_name: str):
+        if col_name in ("best_val_loss", "best_val_iter", "num_params"):
+            return entry.get(col_name)
+        return entry.get("config", {}).get(col_name)
+
+    def apply_bubble_sort(self) -> None:
+        col_name = self.columns[self.sort_column]
+        n = len(self.current_entries)
+        for i in range(n):
+            for j in range(n-i-1):
+                a = self.get_cell(self.current_entries[j], col_name)
+                b = self.get_cell(self.current_entries[j+1], col_name)
+                if (not self.sort_reverse and a > b) or (self.sort_reverse and a < b):
+                    self.current_entries[j], self.current_entries[j+1] = self.current_entries[j+1], self.current_entries[j]
 
     def refresh_table(self, new_cursor: Optional[int] = None) -> None:
         if not self.table:
             return
-        # Reload entries if no active sort to reflect disk changes
-        if self.sort_column is None:
-            self.current_entries = load_runs(self.log_file)
-
-        entries = list(self.current_entries)
-        # Apply bubble sort if requested
+        # Reload data if no sort and no filters
+        if self.sort_column is None and self.current_entries == self.original_entries:
+            self.current_entries = list(self.original_entries)
+        # Apply sort
         if self.sort_column is not None:
-            col_name = self.columns[self.sort_column]
-            def get_val(e: Dict):
-                if col_name in ("best_val_loss", "best_val_iter", "num_params"):
-                    return e.get(col_name)
-                return e.get("config", {}).get(col_name)
-            n = len(entries)
-            for i in range(n):
-                for j in range(0, n - i - 1):
-                    a = get_val(entries[j])
-                    b = get_val(entries[j+1])
-                    if (not self.sort_reverse and a > b) or (self.sort_reverse and a < b):
-                        entries[j], entries[j+1] = entries[j+1], entries[j]
-            # Update current_entries to new sorted order
-            self.current_entries = entries
-
+            self.apply_bubble_sort()
         # Save cursor
         old = self.table.cursor_coordinate
-        row_idx = old.row if old else 0
-        col_idx = new_cursor if new_cursor is not None else (old.column if old else 0)
-
-        # Rebuild headers
+        ri = old.row if old else 0
+        ci = new_cursor if new_cursor is not None else (old.column if old else 0)
+        # Rebuild columns and rows
         self.build_table()
-
-        # Populate rows
-        for e in entries:
+        for e in self.current_entries:
             row = []
             for col in self.columns:
-                if col == "best_val_loss":
-                    val = f"{e.get(col, 0):.6f}"
-                else:
-                    raw = (
-                        e.get(col)
-                        if col in ("best_val_iter", "num_params")
-                        else e.get("config", {}).get(col)
-                    )
-                    val = str(raw)
-                row.append(val)
+                val = self.get_cell(e, col)
+                row.append(f"{val:.6f}" if col=="best_val_loss" else str(val))
             self.table.add_row(*row)
-
-        # Restore cursor position
-        max_row = len(entries) - 1
-        max_col = len(self.columns) - 1
-        r = min(max(row_idx, 0), max_row)
-        c = min(max(col_idx, 0), max_col)
-        self.table.cursor_coordinate = (r, c)
+        # Restore cursor
+        maxr, maxc = len(self.current_entries)-1, len(self.columns)-1
+        self.table.cursor_coordinate = (min(max(ri,0),maxr), min(max(ci,0),maxc))
 
     async def on_key(self, event: events.Key) -> None:
         if not self.table:
@@ -159,61 +189,93 @@ class MonitorApp(App):
         coord = self.table.cursor_coordinate
         if not coord:
             return
-        row, col = coord.row, coord.column
-
+        r, c = coord.row, coord.column
         key = event.key
-        if key == "enter":
-            if self.sort_column == col:
-                # Toggle off sort
+        # Help
+        if key == "?":
+            await self.push_screen(HelpScreen())
+        # Export
+        elif key == "e":
+            fname = f"monitor_export_{int(time.time())}.csv"
+            with open(fname, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(self.columns)
+                for e in self.current_entries:
+                    w.writerow([f"{self.get_cell(e,col):.6f}" if col=="best_val_loss" else str(self.get_cell(e,col)) for col in self.columns])
+            self.bell()
+        # Save layout + filters
+        elif key == "s":
+            filters = []
+            for col_name in self.all_columns:
+                # not storing column filters here—just row_filters list preserved by handlers
+                pass
+            cfg = {
+                "all_columns": self.all_columns,
+                "hidden_cols": list(self.hidden_cols),
+                "sort_column": self.sort_column,
+                "sort_reverse": self.sort_reverse,
+                "row_filters": self.row_filters if hasattr(self, 'row_filters') else []
+            }
+            json.dump(cfg, open(LAYOUT_FILE, "w"))
+            self.bell()
+        # Toggle sort
+        elif key == "enter":
+            if self.sort_column == c:
                 self.sort_column = None
                 self.sort_reverse = False
             else:
-                self.sort_column = col
+                self.sort_column = c
                 self.sort_reverse = False
-            self.refresh_table(new_cursor=col)
-
-        elif key in ("h", "l"):  # move columns
-            target = col - 1 if key == "h" else col + 1
-            if 0 <= target < len(self.columns):
-                # Swap in all_columns
-                name = self.columns[col]
-                other = self.columns[target]
-                idx1 = self.all_columns.index(name)
-                idx2 = self.all_columns.index(other)
-                self.all_columns[idx1], self.all_columns[idx2] = self.all_columns[idx2], self.all_columns[idx1]
-                # Rebuild visible columns
-                self.columns = [c for c in self.all_columns if c not in self.hidden]
-                self.refresh_table(new_cursor=target)
-
-        elif key == "d":  # hide column
-            col_name = self.columns[col]
-            self.hidden.add(col_name)
-            self.columns = [c for c in self.all_columns if c not in self.hidden]
-            self.refresh_table(new_cursor=col)
-
-        elif key == "o":  # unhide all
-            self.hidden.clear()
-            self.columns = self.all_columns.copy()
-            self.refresh_table(new_cursor=col)
+            self.refresh_table(new_cursor=c)
+        # Move columns
+        elif key in ("h","l"):
+            t = c-1 if key=="h" else c+1
+            if 0<=t<len(self.columns):
+                n1,n2 = self.columns[c], self.columns[t]
+                i1,i2 = self.all_columns.index(n1), self.all_columns.index(n2)
+                self.all_columns[i1],self.all_columns[i2] = self.all_columns[i2], self.all_columns[i1]
+                self.columns=[col for col in self.all_columns if col not in self.hidden_cols]
+                self.refresh_table(new_cursor=t)
+        # Hide col
+        elif key == "d":
+            cn = self.columns[c]
+            self.hidden_cols.add(cn)
+            self.columns=[col for col in self.all_columns if col not in self.hidden_cols]
+            self.refresh_table(new_cursor=c)
+        # Unhide cols
+        elif key == "o":
+            self.hidden_cols.clear()
+            self.columns=self.all_columns.copy()
+            self.refresh_table(new_cursor=c)
+        # Hide matching rows
+        elif key == "x":
+            col_name = self.columns[c]
+            val = str(self.get_cell(self.current_entries[r], col_name))
+            self.current_entries = [e for e in self.current_entries if str(self.get_cell(e,col_name)) != val]
+            # record filter
+            self.row_filters = getattr(self, 'row_filters', []) + [(col_name,'hide',val)]
+            self.refresh_table(new_cursor=r)
+        # Inverse filter
+        elif key == "i":
+            col_name = self.columns[c]
+            val = str(self.get_cell(self.current_entries[r], col_name))
+            self.current_entries = [e for e in self.current_entries if str(self.get_cell(e,col_name)) == val]
+            self.row_filters = getattr(self, 'row_filters', []) + [(col_name,'keep',val)]
+            self.refresh_table(new_cursor=0)
+        # Unhide rows
+        elif key == "O":
+            self.current_entries = list(self.original_entries)
+            self.row_filters = []
+            self.refresh_table(new_cursor=0)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Monitor hyperparameter search results (Textual TUI)."
     )
-    parser.add_argument(
-        "log_file",
-        type=Path,
-        help="Path to the YAML log file generated by run_experiments.py",
-    )
-    parser.add_argument(
-        "--interval",
-        type=float,
-        default=5.0,
-        help="Refresh interval in seconds",
-    )
+    parser.add_argument("log_file", type=Path, help="Path to YAML log file")
+    parser.add_argument("--interval", type=float, default=5.0, help="Refresh interval seconds")
     args = parser.parse_args()
-
     app = MonitorApp(args.log_file, args.interval)
     app.run()
 

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Textual app to monitor hyperparameter search results from a YAML log file.
+Refreshes every N seconds, showing all runs in a DataTable view.
+Press Enter on the selected cell to toggle sorting by that column; repeat to clear the sort.
+Use 'h'/'l' to move the selected column left/right, with cursor following.
+Press 'd' to hide the selected column, and 'o' to unhide all hidden columns.
+Preserves cursor position and header order across refreshes.
+"""
+import argparse
+import yaml
+from pathlib import Path
+from typing import Optional, List
+from textual.app import App, ComposeResult
+from textual import events
+from textual.containers import Container
+from textual.widgets import DataTable, Header, Footer
+
+
+def load_runs(log_file: Path) -> List[dict]:
+    docs = []
+    if not log_file.exists():
+        return docs
+    with log_file.open() as f:
+        for doc in yaml.safe_load_all(f):
+            if doc:
+                docs.append(doc)
+    return docs
+
+
+class MonitorApp(App):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+    #table {
+        height: auto;
+        width: 1fr;
+    }
+    """
+
+    def __init__(self, log_file: Path, interval: float) -> None:
+        super().__init__()
+        self.log_file = log_file
+        self.interval = interval
+        self.param_keys: List[str] = []
+        self.columns: List[str] = []
+        self.all_columns: List[str] = []
+        self.hidden: set[str] = set()
+        self.sort_column: Optional[int] = None
+        self.sort_reverse: bool = False
+        self.table: Optional[DataTable] = None
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Container(
+            DataTable(id="table"),
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.table = self.query_one(DataTable)
+        entries = load_runs(self.log_file)
+        # Determine parameter columns
+        keys = set()
+        for e in entries:
+            keys.update(e.get("config", {}).keys())
+        self.param_keys = sorted(keys)
+
+        # Base column ordering
+        base = ["best_val_loss", "best_val_iter", "num_params"] + self.param_keys
+        self.columns = base.copy()
+        self.all_columns = base.copy()
+
+        # Initial table setup
+        self.build_table()
+
+        # Schedule refresh and load
+        self.set_interval(self.interval, self.refresh_table)
+        self.refresh_table()
+
+    def build_table(self) -> None:
+        # Rebuild columns according to self.columns
+        if not self.table:
+            return
+        self.table.clear(columns=True)
+        for col in self.columns:
+            self.table.add_column(col, width=max(12, len(col) + 2))
+
+    def refresh_table(self, new_cursor: Optional[int] = None) -> None:
+        if not self.table:
+            return
+        entries = load_runs(self.log_file)
+        # Apply stable sort if requested
+        if self.sort_column is not None:
+            col_name = self.columns[self.sort_column]
+            entries.sort(
+                key=lambda e: (
+                    e.get(col_name)
+                    if col_name in ("best_val_loss", "best_val_iter", "num_params")
+                    else e.get("config", {}).get(col_name)
+                ),
+                reverse=self.sort_reverse
+            )
+
+        # Save cursor
+        old = self.table.cursor_coordinate
+        row_idx = old.row if old else 0
+        col_idx = new_cursor if new_cursor is not None else (old.column if old else 0)
+
+        # Rebuild headers
+        self.build_table()
+
+        # Populate rows
+        for e in entries:
+            row = []
+            for col in self.columns:
+                if col == "best_val_loss":
+                    val = f"{e.get(col, 0):.6f}"
+                else:
+                    raw = (
+                        e.get(col)
+                        if col in ("best_val_iter", "num_params")
+                        else e.get("config", {}).get(col)
+                    )
+                    val = str(raw)
+                row.append(val)
+            self.table.add_row(*row)
+
+        # Restore cursor position
+        max_row = len(entries) - 1
+        max_col = len(self.columns) - 1
+        r = min(max(row_idx, 0), max_row)
+        c = min(max(col_idx, 0), max_col)
+        self.table.cursor_coordinate = (r, c)
+
+    async def on_key(self, event: events.Key) -> None:
+        if not self.table:
+            return
+        coord = self.table.cursor_coordinate
+        if not coord:
+            return
+        row, col = coord.row, coord.column
+
+        key = event.key
+        if key == "enter":
+            # Toggle sort
+            if self.sort_column == col:
+                self.sort_column = None
+                self.sort_reverse = False
+            else:
+                self.sort_column = col
+                self.sort_reverse = False
+            self.refresh_table(new_cursor=col)
+
+        elif key in ("h", "l"):  # move columns
+            target = col - 1 if key == "h" else col + 1
+            if 0 <= target < len(self.columns):
+                # Swap in all_columns
+                name = self.columns[col]
+                other = self.columns[target]
+                idx1 = self.all_columns.index(name)
+                idx2 = self.all_columns.index(other)
+                self.all_columns[idx1], self.all_columns[idx2] = self.all_columns[idx2], self.all_columns[idx1]
+                # Rebuild visible columns
+                self.columns = [c for c in self.all_columns if c not in self.hidden]
+                self.refresh_table(new_cursor=target)
+
+        elif key == "d":  # hide column
+            col_name = self.columns[col]
+            self.hidden.add(col_name)
+            self.columns = [c for c in self.all_columns if c not in self.hidden]
+            self.refresh_table(new_cursor=col)
+
+        elif key == "o":  # unhide all
+            self.hidden.clear()
+            self.columns = self.all_columns.copy()
+            self.refresh_table(new_cursor=col)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Monitor hyperparameter search results (Textual TUI)."
+    )
+    parser.add_argument(
+        "log_file",
+        type=Path,
+        help="Path to the YAML log file generated by run_experiments.py",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Refresh interval in seconds",
+    )
+    args = parser.parse_args()
+
+    app = MonitorApp(args.log_file, args.interval)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -5,7 +5,8 @@ Refreshes every N seconds, showing all runs in a DataTable view.
 Press Enter on the selected cell to toggle sorting by that column; repeat to clear the sort.
 Use 'h'/'l' to move the selected column left/right, with cursor following.
 Press 'd' to hide the selected column, and 'o' to unhide all hidden columns.
-Preserves cursor position and header order across refreshes.
+Preserves cursor position and header order across refreshes, fully expanding to fill vertical space.
+Only shows horizontal scrollbar if content overflows horizontally; vertical scrollbar appears only if content exceeds available height.
 """
 import argparse
 import yaml
@@ -33,9 +34,14 @@ class MonitorApp(App):
     Screen {
         align: center middle;
     }
-    #table {
-        height: auto;
+    Container {
+        height: 1fr;
+    }
+    DataTable#table {
+        height: 1fr;
         width: 1fr;
+        overflow-x: auto;
+        overflow-y: auto;
     }
     """
 
@@ -54,7 +60,7 @@ class MonitorApp(App):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         yield Container(
-            DataTable(id="table"),
+            DataTable(id="table", zebra_stripes=True),
         )
         yield Footer()
 

--- a/train_args.py
+++ b/train_args.py
@@ -334,9 +334,13 @@ def parse_args():
         help="Which attention variant to use for the Transformer blocks."
     )
 
-    # Inifinite Attention variation
+    # Infinite Attention variation
     model_group.add_argument('--n_qk_head_dim', default=None, type=int)
     model_group.add_argument('--n_v_head_dim', default=None, type=int)
+
+    # qk_norm variations
+    model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norn to q and k before attn")
+    model_group.add_argument("--use_qk_norm_scale",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies norm scale, preloads scale for flash attn, post qk multplication in manual attn")
 
     ## SSM - Attention Varient (same as Hymba)
     model_group.add_argument("--ssm_mamba_expand",   type=int,  default=2)

--- a/train_args.py
+++ b/train_args.py
@@ -339,8 +339,8 @@ def parse_args():
     model_group.add_argument('--n_v_head_dim', default=None, type=int)
 
     # qk_norm variations
-    model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norn to q and k before attn")
-    model_group.add_argument("--use_qk_norm_scale",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies norm scale, preloads scale for flash attn, post qk multplication in manual attn")
+    model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")
+    model_group.add_argument("--use_qk_norm_scale",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies norm scale, preloads scale for flash attn, post qk multiplication in manual attn")
 
     ## SSM - Attention Varient (same as Hymba)
     model_group.add_argument("--ssm_mamba_expand",   type=int,  default=2)

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -299,7 +299,7 @@ class CausalSelfAttention(nn.Module):
                 att = (q @ k.transpose(-2, -1))
 
             if self.use_qk_norm_scale:
-                att = att / self.qk_norm_factor
+                att = att * self.qk_norm_factor
             else:
                 att = att / head_dim
 

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -8,7 +8,7 @@ from variations.linear_variations import linear_dictionary
 from quantization.quantize import fake_quantize_act
 from quantization.quant_utils import set_variant, create_activation_buffers
 from variations.softmax_variations import softmax_dictionary
-from variations.position_encoding_variations import QuantizedEmbedding, RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
+from variations.position_encoding_variations import RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
 
 # Mamba related imports
 # if torch.cuda.is_available():
@@ -24,7 +24,7 @@ class CausalSelfAttention(nn.Module):
         self.start_quant_level = config.start_quant_level
         self.quant_scheduler = config.quant_scheduler
 
-        if (config.n_kv_group == None):
+        if (config.n_kv_group is None):
             config.n_kv_group = config.n_head
         else:
             assert config.n_embd % config.n_kv_group == 0
@@ -54,7 +54,7 @@ class CausalSelfAttention(nn.Module):
         self.c_attn_q = self.linear_variant_q(config.n_embd, config.n_embd, config, self.quantization_attn_dict["quantize_linear_attn_q_method"], self.quantization_attn_dict["quantize_linear_attn_q_bits"], bias=config.bias)
 
         self.n_head = config.n_head
-        if config.n_kv_group == None:
+        if config.n_kv_group is None:
             self.n_kv_group = config.n_head
         else:
             assert config.n_head % config.n_kv_group == 0
@@ -531,7 +531,7 @@ class LinearAttention(nn.Module):
 
 class AttnIdentity(nn.Module):
     def __init__(self, config, fire_pos_enc=None):
-        super(Identity, self).__init__()
+        super(nn.Identity, self).__init__()
 
     def forward(self, x, iter_num=None):
         return x

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -103,6 +103,10 @@ class CausalSelfAttention(nn.Module):
         self.window_size = config.window_size
         print(f"sliding window size: {self.window_size}")
 
+        # qk_norm
+        self.use_qk_norm = config.use_qk_norm
+        self.use_qk_norm_scale = config.use_qk_norm_scale
+
         # Using flex attention
         self.use_flex_attn = config.use_flex_attn
 
@@ -133,6 +137,11 @@ class CausalSelfAttention(nn.Module):
                 self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
                 self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
 
+        # qk norm factor
+        if self.use_qk_norm_scale:
+            L = config.block_size
+            g0 = math.log2(L*L - L)
+            self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
 
         self.flash = True
         if self.window_size is not None:
@@ -251,8 +260,20 @@ class CausalSelfAttention(nn.Module):
             k = self.rotary_emb_k(k)
 
         y = None
+
+        if self.use_qk_norm:
+            q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
+            k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         if self.flash:
+
+            if self.use_qk_norm_scale:
+                # pre-scale Q so that built-in √dₕ division becomes our g scaling
+                head_dim = math.sqrt(k.size(-1))
+                qk_scaling_factor = self.qk_norm_factor * math.sqrt(head_dim)
+                q = q * qk_scaling_factor
+
             # efficient attention using Flash Attention CUDA kernels
             y = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=None, dropout_p=self.dropout if self.training else 0, is_causal=True)
         elif self.use_flex_attn and self.window_size is not None:
@@ -270,11 +291,17 @@ class CausalSelfAttention(nn.Module):
 
             att = None
             # manual implementation of attention
+            head_dim = math.sqrt(k.size(-1))
             if self.n_head != self.n_kv_group:
                 k_repeated = k.repeat_interleave(self.n_head // self.n_kv_group, dim=1)
-                att = (q @ k_repeated.transpose(-2, -1)) / math.sqrt(k.size(-1))
+                att = (q @ k_repeated.transpose(-2, -1))
             else:
-                att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+                att = (q @ k.transpose(-2, -1))
+
+            if self.use_qk_norm_scale:
+                att = att / self.qk_norm_factor
+            else:
+                att = att / head_dim
 
             # apply masks
             if self.window_size is not None:

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -556,11 +556,12 @@ class LinearAttention(nn.Module):
 #         return output
 
 
-class AttnIdentity(nn.Module):
+class AttnIdentity(nn.Identity):
     def __init__(self, config, fire_pos_enc=None):
-        super(nn.Identity, self).__init__()
+        super().__init__()
 
     def forward(self, x, iter_num=None):
+        x = super().forward(x)
         return x
 
 class InfiniteHeadAttention(nn.Module):


### PR DESCRIPTION
# QK Norm and Run Exploration Monitor

## QK Norm

QK Norm paper; https://arxiv.org/abs/2010.04245

QK Norm is generally gaining popularity in the open source community as a modern modification. This entails two things:

1. normalization before softmax
2. dividing QK^T by a learnable parameter initialized with relation to max context length instead of by the head dimension

### parameters added
- `use qk_norm` -- boolean default false to implement norm on q and k before softmax
- `use_qk_norm_scale` -- boolean, default false, to implement the scaling


## Run Exploration Monitor
This adds a live monitor with the following controls:

   * **Enter**: Toggle sort on focused column
   * **h/l**: Shift columns in `all_columns` list and refresh view
   * **d**: Add to `hidden` set and remove from display
   * **o**: Clear `hidden` set and restore all columns

### Example Invocation:

The following is an example invocation:
```sh
python3 run_exploration_monitor.py exploration_logs/qk_norm.yaml --interval 5
```

### Screencapture

![image](https://github.com/user-attachments/assets/b0114d6b-a888-4ebb-962b-78c4bfe6f66c)
