### PR TITLE
lm_eval added to train.py

### DIFF
--- a/benchmarks/gpt_lm_eval_wrapper.py
+++ b/benchmarks/gpt_lm_eval_wrapper.py
@@ -192,13 +192,17 @@ class NanoGPTLM(model_api.LM):
     
     @classmethod
     def create_model(cls, model, encode_fn, decode_fn, args):
+        max_new = getattr(args, "max_benchmark_tokens", None)
+        if max_new is None:
+            max_new = getattr(args, "max_new_tokens", None)
+
         return cls(
             model=model,
             tokenizer_encode=encode_fn,
             tokenizer_decode=decode_fn,
             eot_token_id=model.config.vocab_size - 1, # |endoftext| token is the last token in GPT2
             device=args.device,
-            max_new_tokens=args.max_new_tokens,
+            max_new_tokens=max_new,
             batch_size=args.batch_size,
             temperature=args.temperature,
             top_k=args.top_k,

--- a/train_args.py
+++ b/train_args.py
@@ -40,6 +40,12 @@ def parse_args():
     training_group.add_argument('--sample_start_tokens', default='\n', type=str)
     training_group.add_argument('--sample_only', default=False, action=argparse.BooleanOptionalAction, help="Run only the sampling process and exit")
 
+    # lm_eval args
+    training_group.add_argument("--lm_eval_tasks", type=str, default=None, help="Comma-separated list of lm-eval tasks to run (e.g. arc_easy,hellaswag)")
+    training_group.add_argument('--max_benchmark_tokens', default=500, type=int, help="Max number of tokens to generate when benchmarking")
+    training_group.add_argument('--benchmark_each_eval', default=False, action=argparse.BooleanOptionalAction, help="Produce benchmarking results even if the validation loss did not improve.")
+    training_group.add_argument("--lm_eval_results_output", type=str, default="final_lm_eval", help="If set, write full lm-eval JSON to this path")
+
     # Checkpoint args
     training_group.add_argument('--save_major_ckpt_interval', default=None, type=int, help="Interval for saving major checkpoints.")
     training_group.add_argument('--only_save_checkpoint_at_end', default=False, action=argparse.BooleanOptionalAction)


### PR DESCRIPTION
Added lm_eval arguments to train.py:
--**lm_eval_tasks**: comma-separated list of LM-Eval task names (e.g. hellaswag,arc_easy)
--**max_benchmark_tokens**: max number of tokens to generate when benchmarking
--**benchmark_each_eval**: whether to re-run LM-Eval on every validation pass or just when the validation loss improves by default
--lm_eval_results_output : path to write the JSON results (defaults to "out_dir/final_lm_eval.json")

**Example Invocation**:
python3 train.py --dataset=wikitext103 --lm_eval_tasks=arc_easy,hellaswag --max_benchmark_tokens=500

**Example Output**:
![image](https://github.com/user-attachments/assets/bd3775f0-156d-49a5-97aa-e1871ea00200)
![image](https://github.com/user-attachments/assets/bb7b5481-132a-4953-a19c-1fc42ee33c1a)