### PR TITLE
Update inf_attn for flash_lobo exploration

### DIFF
--- a/data/template/utils/large_file_prepare.sh
+++ b/data/template/utils/large_file_prepare.sh
@@ -2,4 +2,4 @@
 
 input_file=${1:-input.txt}
 python3 ./utils/partition_file.py --input_file "${input_file}"
-python3 ./utils/batch_prepare.py --input_dir partitioned_file --prepare_script prepare.py --tokenizer char
+python3 ./utils/batch_prepare.py --input_dir partitioned_file --prepare_script prepare.py --tokenizer tiktoken

--- a/explorations/infinite_cproj.yaml
+++ b/explorations/infinite_cproj.yaml
@@ -2,13 +2,14 @@
 ---
 
 # base hyperparameters
-max_iters: [10000]
+max_iters: [20000]
 # n_layer: [6]
 # n_head: [6]
 # n_embd: [384]
 # block_size: [256]
+eval_interval: [500]
 device: ["cuda"]
-dataset: ["cosmopedia_100k"]
+dataset: ["minipile"]
 
 # uses rotary embeddings, no abs pos embeddings
 use_rotary_embeddings: [true]
@@ -33,13 +34,14 @@ flash_lobo_log_const:
 # --- END FLASH LOBO OPTIONS ------
 
 # --- BEGIN CONCAT HEADS OPTIONS -----
+attention_variant: "infinite"
 
 # check if mantissa or exp improves
 dtype: ["bfloat16", "float16"]
 
 # inf head allowed, test if this scales better with lobo
 n_head: [6, 12, 18]
-use_concat_heads: [true, false]
+use_concat_heads: [false, true]
 n_cproj:
   conditions:
     - ["use_concat_heads", false]

--- a/explorations/infinite_cproj.yaml
+++ b/explorations/infinite_cproj.yaml
@@ -1,0 +1,53 @@
+# infinite_cproj.yaml
+---
+
+# base hyperparameters
+max_iters: [10000]
+# n_layer: [6]
+# n_head: [6]
+# n_embd: [384]
+# block_size: [256]
+device: ["cuda"]
+dataset: ["cosmopedia_100k"]
+
+# uses rotary embeddings, no abs pos embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
+
+# compilation
+compile: [true]
+
+# --- BEGIN FLASH LOBO OPTIONS ------
+use_flash_lobo: [true, false]
+
+use_flash_lobo_per_head:
+  conditions:
+    - ["use_flash_lobo", true]
+  options: [true]
+
+flash_lobo_log_const:
+  conditions:
+    - ["use_flash_lobo", true]
+  options: ["0.1", "0.5"]
+
+# --- END FLASH LOBO OPTIONS ------
+
+# --- BEGIN CONCAT HEADS OPTIONS -----
+
+# check if mantissa or exp improves
+dtype: ["bfloat16", "float16"]
+
+# inf head allowed, test if this scales better with lobo
+n_head: [6, 12, 18]
+use_concat_heads: [true, false]
+n_cproj:
+  conditions:
+    - ["use_concat_heads", false]
+  options: ["1", "6", "12", "18"]
+
+# test if higher concat_heads or higher n_head scales better with higher n_v_dim
+n_qk_head_dim: [64]
+n_v_head_dim: [64, 80, 96]
+
+# --- END CONCAT HEADS OPTIONS -----
+

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -17,6 +17,8 @@ class GPTConfig:
     ## Inf attention variation
     n_qk_head_dim: int = None
     n_v_head_dim: int = None
+    n_cproj: int = None
+    use_concat_heads: bool = False
 
     # Learned Position Embeddings
     n_lpe: int = 0

--- a/hp_searches/lobo_attnhead_search.sh
+++ b/hp_searches/lobo_attnhead_search.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# lobo_attnhead_search.sh
+
+python3 hyperparam_search.py \
+  --orig_settings ./hp_searches/lobo_attnhead_search.yaml \
+  --param_names \
+        n_layer \
+        n_head \
+        n_embd \
+        mlp_size \
+        n_qk_head_dim \
+        n_v_head_dim \
+        flash_lobo_log_const \
+  --increments \
+        1 \
+        1 \
+        16 \
+        16 \
+        16 \
+        16 \
+        0.1 \
+  --random_iterations 3 \
+  --iterations 1 \
+  --num_iterations 2000 \
+  --results_file results.yaml
+

--- a/hp_searches/lobo_attnhead_search.yaml
+++ b/hp_searches/lobo_attnhead_search.yaml
@@ -1,0 +1,21 @@
+# static
+dataset: "minipile"
+use_rotary_embeddings: True
+use_abs_pos_embeddings: False
+use_flash_lobo: true
+use_flash_lobo_per_head: true
+use_concat_heads: True
+attention_variant: "infinite"
+max_iters: 7500
+eval_interval: 500
+compile: True
+batch_size: 32
+block_size: 512
+# changeable things
+n_layer: 1
+n_head: 1
+n_embd: 32
+mlp_size: 32
+n_qk_head_dim: 32
+n_v_head_dim: 32
+flash_lobo_log_const: 0.1

--- a/logging/start_tensorboard.sh
+++ b/logging/start_tensorboard.sh
@@ -9,4 +9,4 @@ if [ ! -z "$1" ]; then
   PORT="$1"
 fi
 
-tensorboard --logdir=./logs --port="$PORT" || python3 -m tensorboard.main --logdir=./logs --port="$PORT"
+tensorboard --logdir=./logs --port="$PORT" --bind_all | python3 -m tensorboard.main --logdir=./logs --port="$PORT" --bind_all

--- a/train_args.py
+++ b/train_args.py
@@ -337,6 +337,8 @@ def parse_args():
     ## Infinite Attention variation
     model_group.add_argument('--n_qk_head_dim', default=None, type=int)
     model_group.add_argument('--n_v_head_dim', default=None, type=int)
+    model_group.add_argument('--n_cproj', default=None, type=int)
+    model_group.add_argument("--use_concat_heads",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="concat heads instead of adding in infinite attention")
 
     ## qk_norm variations
     model_group.add_argument("--use_qk_norm",   type=bool, default=False, action=argparse.BooleanOptionalAction, help="applies the norm to q and k before attn")

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -1,14 +1,17 @@
 # variations/attention_variations.py
 
 import math
+
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
-from variations.linear_variations import linear_dictionary
+
+from quantization.quant_utils import create_activation_buffers, set_variant
 from quantization.quantize import fake_quantize_act
-from quantization.quant_utils import set_variant, create_activation_buffers
+from variations.linear_variations import linear_dictionary
+from variations.position_encoding_variations import (
+    FIRE, RotaryEmbedding, SymmetricalOverlapAngularPositions)
 from variations.softmax_variations import softmax_dictionary
-from variations.position_encoding_variations import RotaryEmbedding, SymmetricalOverlapAngularPositions, FIRE
 
 # Mamba related imports
 # if torch.cuda.is_available():
@@ -625,9 +628,30 @@ class InfiniteHeadAttention(nn.Module):
         super().__init__()
 
         self.n_head = config.n_head
+
+        # group query attention and fallback
+        if (config.n_kv_group is None):
+            self.n_kv_group = config.n_head
+        else:
+            assert config.n_embd % config.n_kv_group == 0
+            self.n_kv_group = config.n_kv_group
+
         self.n_embd = config.n_embd
         self.n_qk_head_dim = config.n_qk_head_dim
         self.n_v_head_dim = config.n_v_head_dim
+
+        # Concat Heads
+        self.use_concat_heads = config.use_concat_heads
+        self.n_cproj         = config.n_cproj
+
+        # QK Norm
+        self.use_qk_norm        = config.use_qk_norm
+        self.use_qk_norm_scale  = config.use_qk_norm_scale
+
+        # Flash Lobo
+        self.use_flash_lobo         = config.use_flash_lobo
+        self.use_flash_lobo_per_head= config.use_flash_lobo_per_head
+        self.disable_flash_attention = config.disable_flash_attention
 
         self.linear_variant_q = linear_dictionary[config.linear_variant_attn]
         self.linear_variant_k = linear_dictionary[config.linear_variant_attn]
@@ -638,7 +662,18 @@ class InfiniteHeadAttention(nn.Module):
         self.c_attn_q = self.linear_variant_q(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
         self.c_attn_k = self.linear_variant_k(self.n_embd, self.n_head * self.n_qk_head_dim, config, bias=config.bias)
         self.c_attn_v = self.linear_variant_v(self.n_embd, self.n_head * self.n_v_head_dim, config, bias=config.bias)
-        self.c_proj = self.linear_variant_attn_proj(self.n_v_head_dim, self.n_embd, config, bias=config.bias)
+
+        if self.use_concat_heads:
+            self.c_proj = self.linear_variant_attn_proj(
+                self.n_head * self.n_v_head_dim, self.n_embd, config, bias=config.bias
+            )
+        else:
+            self.c_proj_list = nn.ModuleList(
+                [
+                    self.linear_variant_attn_proj(self.n_v_head_dim, self.n_embd, config, bias=config.bias)
+                    for _ in range(self.n_cproj)
+                ]
+            )
 
         # Regularization
         self.attn_dropout = nn.Dropout(config.dropout)
@@ -647,11 +682,26 @@ class InfiniteHeadAttention(nn.Module):
 
         # Embedding
         self.n_embd = config.n_embd
-        self.dropout = config.dropout
 
         # Rotary Positional Embeddings
         self.rotary_emb_q = None
         self.rotary_emb_k = None
+
+        if config.use_rotary_embeddings:
+            # Note: size is the size of the head dimension
+            if config.rope_variant == "soap":
+                self.sym_rot_num_angles = config.sym_rot_num_angles
+                self.rotary_emb_q = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
+                self.rotary_emb_k = SymmetricalOverlapAngularPositions(config, size=config.n_embd // self.n_head, num_angles=self.sym_rot_num_angles)
+            elif config.rope_variant == "rope":
+                self.rotary_emb_q = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+                self.rotary_emb_k = RotaryEmbedding(config, size=config.n_embd // self.n_head)
+
+        # qk norm factor
+        if self.use_qk_norm_scale:
+            L = config.block_size
+            g0 = math.log2(L*L - L)
+            self.qk_norm_factor = nn.Parameter(torch.tensor(g0))
 
         # Softmax Variant Selection
         self.softmax_variant_attn = config.softmax_variant_attn
@@ -672,24 +722,88 @@ class InfiniteHeadAttention(nn.Module):
         k = k.view(B, T, self.n_head, self.n_qk_head_dim).transpose(1, 2) # (B, n_kv, T, hs)
         v = v.view(B, T, self.n_head, self.n_v_head_dim).transpose(1, 2) # (B, n_kv, T, hs)
 
+        # Apply Rotary Position Encodings
+        if (self.rotary_emb_q is not None) and (self.rotary_emb_k is not None):
+            q = self.rotary_emb_q(q)
+            k = self.rotary_emb_k(k)
+
+        # Apply QK Norm
+        if self.use_qk_norm:
+            q = q / (q.norm(dim=-1, keepdim=True) + 1e-6)
+            k = k / (k.norm(dim=-1, keepdim=True) + 1e-6)
+
         y = None
         att = None
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
-        # manual implementation of attention
-        att = (q @ k.transpose(-2, -1)) * (1.0 / torch.sqrt(torch.tensor([k.size(-1)], dtype=q.dtype, device=q.device)))
+        if self.flash:
+            # Flash QK Norm
+            if self.use_qk_norm_scale:
+                # pre-scale Q so that built-in √dₕ division becomes our g scaling
+                head_dim = math.sqrt(k.size(-1))
+                qk_scaling_factor = self.qk_norm_factor * math.sqrt(head_dim)
+                q = q * qk_scaling_factor
 
-        # apply lower triangle attention mask
-        att = att.masked_fill(self.bias[:,:,:T,:T].to(x.device) == 0, float('-inf'))
+            # Flash Lobo
+            attn_bias = None
+            if self.use_flash_lobo:
+                # 2-a  Make dummy key/value column of zeros
+                dummy_k = q.new_zeros(B, self.n_kv_group, 1, q.size(-1))
+                dummy_v = q.new_zeros(B, self.n_kv_group, 1, v.size(-1))
 
-        # softmax variation
-        if self.softmax_variant_attn != 'softmax':
-            att = self.softmax_layer_attn(att)
+                k = torch.cat([dummy_k, k], dim=2)   # prepend → causal mask still valid
+                v = torch.cat([dummy_v, v], dim=2)
+
+                # 2-b  Bias only that column with log C
+                attn_bias = q.new_zeros(1, self.n_head, 1, k.size(2))
+                if self.use_flash_lobo_per_head:
+                    attn_bias[..., 0] = self.flash_lobo_log_const.view(1, self.n_head, 1)
+                else:
+                    attn_bias[..., 0] = self.flash_lobo_log_const    # first column only
+
+
+            # Efficient attention using Flash Attention CUDA kernels
+            y = torch.nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_bias,
+                dropout_p=self.dropout if self.training else 0,
+                is_causal=True,
+            )
+
         else:
-            att = F.softmax(att, dim=-1)
+            # manual implementation of attention
+            att = (q @ k.transpose(-2, -1)) * (1.0 / torch.sqrt(torch.tensor([k.size(-1)], dtype=q.dtype, device=q.device)))
+
+            if self.use_qk_norm_scale:
+                # utilize learned qk_norm_scaling factor
+                att = att * self.qk_norm_factor
+            else:
+                # divide by head dimension if not
+                att = att / torch.sqrt(torch.tensor([k.size(-1)], dtype=q.dtype, device=q.device))
+
+            # apply lower triangle attention mask
+            att = att.masked_fill(self.bias[:,:,:T,:T].to(x.device) == 0, float('-inf'))
+
+            # softmax variation
+            if self.softmax_variant_attn != 'softmax':
+                att = self.softmax_layer_attn(att)
+            else:
+                att = F.softmax(att, dim=-1)
 
         att = self.attn_dropout(att)
 
-        y = (att @ v).sum(dim=1)  # Sum over all heads instead of concatenation
+        # Concat Heads or Inf Concat Heads
+        if self.use_concat_heads:
+            # (B, nh, T, v_dim) → (B, T, nh*v_dim); avoid extra .contiguous()
+            y = att.transpose(1, 2).reshape(B, T, -1)
+            y = self.c_proj(y)
+        else:
+            # Sum heads first: (B, nh, T, v_dim) → (B, T, v_dim)
+            y_sum = att.sum(dim=1)
+
+            # Parallel small projections then fuse; avoids Python-level loop
+            y = torch.stack([proj(y_sum) for proj in self.c_proj_list ], dim=0).sum(dim=0)
 
         # output projection
         y = self.resid_dropout(self.c_proj(y))

--- a/variations/attention_variations.py
+++ b/variations/attention_variations.py
@@ -817,7 +817,8 @@ class InfiniteHeadAttention(nn.Module):
         # Concat Heads or Inf Concat Heads
         if self.use_concat_heads:
             # (B, nh, T, v_dim) → (B, T, nh*v_dim); avoid extra .contiguous()
-            y = att.transpose(1, 2).reshape(B, T, C)
+            # flatten heads → (B, T, n_head * n_v_head_dim)
+            y = y.transpose(1, 2).contiguous().view( B, T, self.n_head * self.n_v_head_dim)
             y = self.c_proj(y)
         else:
             # Sum heads first: (B, nh, T, v_dim) → (B, T, v_dim)


### PR DESCRIPTION
# Infinite Attention and Residual Dimension Bottleneck

This PR explores two possible bottlenecks for the encountered cap when adding more attention heads: attention noise and limit of the c_proj feature count

## Insights from JL Studies:
- we can add instead of concatenate, can treat learned vectors as "one-hots"
- capacity of vector increases exponentially with dimension
- we can store more information in our residual than the number of dimensions

## Potential pitfalls:
- c_proj extracts features, but # of feature vectors extracted = *n_head x embedding_dim* for regular attn or "1 x embedding_dim" in original exploration.
- Attention heads add noise (as one option needs to be ~1), adding more heads can compound this noise

## Solutions:
- Add Lobo for attention to self filter noise
- Increase value vector dimension for greater capacity
- add results of value vectors to allow for inf_cproj, where features are now *n_cproj x embedding dim*, *and* operate along all heads instead of just their prior head.

## Summary 
So here we experiment with flash lobo x inf cproj, seeing if this allows more heads per layer at a given size embedding dimension.

We will check if:
1. par performance or greater with same c_proj features (concat and non_concat)
2. flash_lobo allows better val loss curves as we increase number of heads
3. effects of both of the above curves as we increase the *value vector size*.

### Note/TODO
Another test, would be to check if we can use infinite queries, with just one kv group with flash_lobo and higher v_head_dimension, but will leave this to a follow-up commit,