### PR TITLE
Logit Softcapping

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -20,6 +20,10 @@ class GPTConfig:
     n_cproj: int = None
     use_concat_heads: bool = False
 
+    # Softcapping params
+    attn_logit_softcapping: bool = False
+    final_logit_softcapping: bool = False
+
     # Learned Position Embeddings
     n_lpe: int = 0
     lpe_block_size: int = 1024

--- a/train_args.py
+++ b/train_args.py
@@ -156,6 +156,8 @@ def parse_args():
     model_group.add_argument('--moe_top_k', default=2, type=int)
     model_group.add_argument('--moe_router_scheme', default="softmax", type=str, help="option to set routing scheme for MoE layer, defaults to softmax")
     model_group.add_argument('--use_flex_attn', default=None,  action=argparse.BooleanOptionalAction, help="option for using flex attention for sliding windows")
+    model_group.add_argument('--attn_logit_softcapping', default=None, action=argparse.BooleanOptionalAction, help="option for softcapping attention (before masking)")
+    model_group.add_argument('--final_logit_softcapping', default=None, action=argparse.BooleanOptionalAction, help="option for softcapping final logits")
 
     ## Manual Steering Vector Options
 


### PR DESCRIPTION
Added attention and final logit softcapping as implemented [here](https://github.com/google/gemma_pytorch/blob/main/gemma/model.py) for the Gemma 2 model. 

Attention logit softcapping does softcapping right before the masking.

Final logit softcapping does softcapping for the final logits of the model. 