### PR TITLE
Modify settings for comparing ipawbf and tiktoken

### DIFF
--- a/demos/ja_snac.sh
+++ b/demos/ja_snac.sh
@@ -12,7 +12,7 @@ bash get_dataset.sh
 popd
 
 # running the training
-python3 optimization_and_search/run_experiments.py --config explorations/stt.yaml --config_format yaml --output_dir snac_ipa_ja_outs
+python3 optimization_and_search/run_experiments.py --config explorations/stt_ipabytefallback.yaml --config_format yaml --output_dir snac_ipa_bf_ja_outs
 
 # Doing the tiktoken tokenizer
 pushd "data/snac_cvja"
@@ -20,4 +20,4 @@ python3 prepare.py -t ja_snac_text.txt --method tiktoken
 popd
 
 # running the training
-python3 optimization_and_search/run_experiments.py --config explorations/stt.yaml --config_format yaml --output_dir snac_text_ja_outs
+python3 optimization_and_search/run_experiments.py --config explorations/stt_tiktoken.yaml --config_format yaml --output_dir snac_tiktoken_ja_outs

--- a/explorations/stt_ipabytefallback.yaml
+++ b/explorations/stt_ipabytefallback.yaml
@@ -1,0 +1,26 @@
+# stt_ipabytefallback.yaml
+---
+# parameter_groups: define sets of overrides to apply on top of base params
+parameter_groups:
+  - use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+# base hyperparameters
+max_iters: [10000]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [1024]
+device: ["cuda"]
+dtype: ["float16"]
+dataset: ["snac_cvja"]
+
+# boolean flags
+compile: [true]
+
+# tensorboard run name
+tensorboard_run_name: ["stt_ipabytefallback"]
+sample_each_eval: [true]
+max_sample_tokens: [800]
+colorize_output: [true]
+colorization_mode: ["all"]

--- a/explorations/stt_tiktoken.yaml
+++ b/explorations/stt_tiktoken.yaml
@@ -1,0 +1,26 @@
+# stt_tiktoken.yaml
+---
+# parameter_groups: define sets of overrides to apply on top of base params
+parameter_groups:
+  - use_rotary_embeddings: [true]
+    use_abs_pos_embeddings: [false]
+
+# base hyperparameters
+max_iters: [10000]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [1024]
+device: ["cuda"]
+dtype: ["float16"]
+dataset: ["snac_cvja"]
+
+# boolean flags
+compile: [true]
+
+# tensorboard run name
+tensorboard_run_name: ["stt_tiktoken"]
+sample_each_eval: [true]
+max_sample_tokens: [800]
+colorize_output: [true]
+colorization_mode: ["all"]

--- a/train_args.py
+++ b/train_args.py
@@ -267,7 +267,7 @@ def parse_args():
     training_group.add_argument('--token_boundary', type=str, default=None, help="Optional separator string between emitted tokens (for decode).")
     training_group.add_argument('--num_samples', type=int, default=1, help="Number of generated samples during sampling.")
     training_group.add_argument('--temperature', type=float, default=0.8, help="Temperature for predictions (1.0 = normal, < 1.0 = less random).")
-    training_group.add_argument('--top_k', type=int, nargs='+', default=[2, 5, 10, 20], help="Retain only the top_k most likely tokens (used in sample.py).")
+    training_group.add_argument('--top_k', type=int, nargs='+', default=[1, 2, 5, 10], help="Retain only the top_k most likely tokens (used in sample.py).")
     training_group.add_argument('--eval_dataset', type=str, default=None, help="Optional dataset name for custom evaluation splits.")
     training_group.add_argument('--quantization_data_file', type=str, default=None, help="If set, export quantized weights/activations to a specified file (pkl).")
 


### PR DESCRIPTION
Created additional yaml config files so that run_experiments will recognize they are different configurations (differing in this case by tokenization, which is not something covered yet in the yaml).

Also changed the top k list to start with 1 2 5 10, instead of 2 5 10 20.