### PR TITLE
Add multibar chart to run_experiments_monitor.py

### DIFF
--- a/explorations/optimizers.yaml
+++ b/explorations/optimizers.yaml
@@ -20,6 +20,7 @@ optimizer:
 # paper-driven implementations
 - orthoadam
 - adams
+- ademamix
 # hybrids
 - lambdiff
 - adamod_diffgrad

--- a/run_exploration_monitor.py
+++ b/run_exploration_monitor.py
@@ -19,6 +19,8 @@ Interactive keybindings:
   q # # - multibarcharts - `q [1-9] [1-9]` - e.g. 'q 3 2' will create bar charts for columns 1 2 and 3, the next two columns (column 4 and column 5) as merged labels.
   w–y   - barcharts with labels merged (w=1, y =5)
   c     - toggle colour-map on first column (green → red)
+  u     - unsort / remove current column from the sort stack
+  U     - clear *all* sorting
 
 Use `--hotkeys` to print this help and exit.
 """
@@ -33,6 +35,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import yaml
+import math
 from textual import events
 from textual.app import App, ComposeResult
 from textual.containers import Container
@@ -71,6 +74,8 @@ HOTKEYS_TEXT = (
     "q # #: multibarcharts - `q [1-9] [1-9]` - e.g. 'q 3 2' will create bar charts for columns 1 2 and 3, the next two columns (column 4 and column 5) as merged labels\n"
     "w–y: barcharts with labels merged (w=1, y =5)\n"
     "c: toggle colour-map on first column (green → red)\n"
+    "u: unsort / remove current column from the sort stack\n"
+    "U: clear *all* sorting\n"
 )
 
 
@@ -96,7 +101,7 @@ class MonitorApp(App):
         self.columns: List[str] = []
         self.all_columns: List[str] = []
         self.hidden_cols: set[str] = set()
-        self.sort_stack : List[int] = []
+        self.sort_stack: List[tuple[int, bool]] = []
         self.table: Optional[DataTable] = None
         self.original_entries: List[Dict] = []  # Unfiltered data
         self.current_entries: List[Dict] = []  # View data with filters
@@ -132,7 +137,7 @@ class MonitorApp(App):
             self.all_columns = cfg.get("all_columns", self.all_columns)
             self.hidden_cols = set(cfg.get("hidden_cols", []))
             self.columns = [c for c in self.all_columns if c not in self.hidden_cols]
-            self.sort_stack = cfg.get("sort_stack", [])
+            self.sort_stack = [tuple(p) for p in cfg.get("sort_stack", [])]
             # Restore saved row filters
             self.row_filters = cfg.get("row_filters", [])
             self.current_entries = list(self.original_entries)
@@ -169,14 +174,22 @@ class MonitorApp(App):
         return entry.get("config", {}).get(col_name)
 
     @staticmethod
-    def _sort_key(v):
+    def _is_missing(v) -> bool:
+        """Return *True* for values that should always sink to the bottom."""
+        return (
+            v is None
+            or (isinstance(v, float) and math.isnan(v))
+        )
+    @classmethod
+    def _sort_key(cls, v):
         """
-        Build a key that always puts ``None`` LAST (higher than any value),
-        and otherwise uses the raw value when comparable, or its string
-        representation as a tiebreaker for mixed types.
+        Build a key that always puts “missing” values (*None* or *NaN*) LAST,
+        regardless of ascending / descending order; for everything else use the
+        raw value when comparable, falling back to its string representation for
+        mixed types.
         """
-        if v is None:
-            return (1, "")            #  ❖  None  ← bottom
+        if cls._is_missing(v):
+            return (1, "")            #  sink
         return (0, v if isinstance(v, (int, float, str)) else str(v))
 
     def apply_progressive_sort(self) -> None:
@@ -185,10 +198,19 @@ class MonitorApp(App):
         later keys in ``self.sort_stack`` take precedence, but the ordering
         within equal keys respects the earlier sorts (Python sort is stable).
         """
-        for col_idx in reversed(self.sort_stack):
+        # NOTE:  we iterate **in insertion order** (oldest → newest).  
+        # Because Python’s sort is *stable*, the **last** pass has the
+        # highest precedence — therefore the *most-recent* “Enter” press
+        # wins, exactly as requested.
+        for col_idx, asc in self.sort_stack:
             col_name = self.columns[col_idx]
             self.current_entries.sort(
-                key=lambda e: self._sort_key(self.get_cell(e, col_name))
+                key=lambda e: self._sort_key(self.get_cell(e, col_name)),
+                reverse=not asc,
+            )
+            # second pass → ensure None/NaN always sink
+            self.current_entries.sort(
+                key=lambda e: self._is_missing(self.get_cell(e, col_name))
             )
 
     @staticmethod
@@ -379,22 +401,34 @@ class MonitorApp(App):
             cfg = {
                 "all_columns": self.all_columns,
                 "hidden_cols": list(self.hidden_cols),
-                "sort_stack":  self.sort_stack,
+                "sort_stack":  [[i, asc] for i, asc in self.sort_stack],
                 "row_filters": getattr(self, "row_filters", []),
             }
             self.config_file.write_text(json.dumps(cfg, indent=2))
             self.bell()
             self._msg("Layout saved")
         elif key == "enter":
-            # ── progressive column sort ─────────────────────────────
-            if c in self.sort_stack:
-                self.sort_stack.remove(c)   # move to *most-recent* position
-            self.sort_stack.append(c)
+            # ── direction-cycling progressive sort ──────────────────
+            idx = next((k for k, (col, _) in enumerate(self.sort_stack) if col == c), None)
+
+            if idx is None:                      # not yet in stack → ascending
+                self.sort_stack.append((c, True))
+                state_txt = "↑"
+            else:
+                col, asc = self.sort_stack.pop(idx)        # remove old entry
+                if asc:                     # ascend → descend
+                    self.sort_stack.append((col, False))
+                    state_txt = "↓"
+                else:                       # descend → remove
+                    state_txt = "✕"         # no sort for this col
             self.refresh_table(new_cursor=c)
 
             if self.sort_stack:
-                path = " ➜ ".join(self.columns[i] for i in self.sort_stack)
-                self._msg(f"Sort order: {path}")
+                parts = [
+                    f"{self.columns[i]}{'↑' if asc else '↓'}"
+                    for i, asc in self.sort_stack
+                ]
+                self._msg(" • ".join(parts))
             else:
                 self._msg("Sorting cleared")
         elif key in ("h", "l"):
@@ -474,6 +508,29 @@ class MonitorApp(App):
             state = "enabled" if self.colour_first else "disabled"
             self.refresh_table()
             self._msg(f"First-column colour-map {state}")
+        elif key == "u":
+            # ── remove current column from sort stack ────────────────────
+            before = len(self.sort_stack)
+            self.sort_stack = [(col, asc) for col, asc in self.sort_stack if col != c]
+            if len(self.sort_stack) != before:
+                self.refresh_table(new_cursor=c)
+                if self.sort_stack:
+                    parts = [
+                        f"{self.columns[i]}{'↑' if asc else '↓'}"
+                        for i, asc in self.sort_stack
+                    ]
+                    self._msg("Sort order: " + " • ".join(parts))
+                else:
+                    self._msg("Sorting cleared")
+            else:
+                self._msg("Column wasn’t in sort order")
+        elif key == "U":
+            if self.sort_stack:
+                self.sort_stack.clear()
+                self.refresh_table(new_cursor=c)
+                self._msg("All sorting cleared")
+            else:
+                self._msg("No active sorting")
         elif key.isdigit() and key != "0":  # keys '1'–'9'
             n = int(key)
             try:

--- a/train_args.py
+++ b/train_args.py
@@ -122,6 +122,7 @@ def parse_args():
             "adabelief",
             "orthoadam",
             "adams",
+            "ademamix",
             "adan",
             "apollo_adamw",
             "qhadam",
@@ -165,11 +166,11 @@ def parse_args():
     training_group.add_argument("--adams_beta1", type=float, default=0.9, help="Beta1 for AdamS optimizer.")
     training_group.add_argument("--adams_beta2", type=float, default=0.95, help="Beta2 for AdamS optimizer. Paper suggests 0.95 vs 0.999 for numerical stability.")
     # --------  ADEMAMIX --------------------------------------------------
-    training_group.add_argument("--adedamix_beta1", type=float, default=0.9, help="β1 hyper-parameter for the Adedamix optimizer.")
-    training_group.add_argument("--adedamix_beta2", type=float, default=0.999, help="β2 hyper-parameter for the Adedamix optimizer.")
-    training_group.add_argument("--adedamix_beta3", type=float, default=0.9999, help="β3 hyper-parameter for the Adedamix optimizer.")
-    training_group.add_argument("--adedamix_alpha", type=float, default=8, help="α (scaling factor) for the Adedamix optimizer.")
-    training_group.add_argument("--adedamix_warmup", type=int, default=2000, help="Number of warm-up steps for Adedamix’s learning-rate schedule.")
+    training_group.add_argument("--ademamix_beta1", type=float, default=0.9, help="β1 hyper-parameter for the Ademamix optimizer.")
+    training_group.add_argument("--ademamix_beta2", type=float, default=0.999, help="β2 hyper-parameter for the Ademamix optimizer.")
+    training_group.add_argument("--ademamix_beta3", type=float, default=0.9999, help="β3 hyper-parameter for the Ademamix optimizer.")
+    training_group.add_argument("--ademamix_alpha", type=float, default=8, help="α (scaling factor) for the Ademamix optimizer.")
+    training_group.add_argument("--ademamix_warmup", type=int, default=2000, help="Number of warm-up steps for Ademamix’s learning-rate schedule.")
     # --------  NADAM --------------------------------------------------
     training_group.add_argument("--nadam_betas", type=float, nargs=2, default=[0.9, 0.999], help="Betas for Nadam optimizer.")
     training_group.add_argument("--nadam_eps", type=float, default=1e-8, help="Epsilon for Nadam optimizer.")

--- a/train_variations/optimizer_variants.py
+++ b/train_variations/optimizer_variants.py
@@ -1,6 +1,7 @@
 # train_variations/optimizer_variants.py
 from __future__ import annotations
 
+import math
 import torch
 from torch.optim import (ASGD, LBFGS, SGD, Adagrad, Adam, Adamax, AdamW, NAdam,
                          RAdam, RMSprop, SparseAdam)
@@ -284,11 +285,11 @@ class AdEMAMix(Optimizer):
 def _ademamix(param_groups, args):
     return AdEMAMix(
         param_groups,
-        lr=args.lr,
+        lr=args.learning_rate,
         betas=(args.ademamix_beta1, args.ademamix_beta2, args.ademamix_beta3),
         alpha=args.ademamix_alpha,
         T_alpha_beta3=args.ademamix_warmup,
-        eps=args.eps,
+        eps=args.opt_eps,
         weight_decay=args.weight_decay,
     )
 


### PR DESCRIPTION
# Multibar Chart Description

This allows for us to create bar charts for multiple categories, e.g. optimizer val loss, peak gpu, iteration avg latency, from the run_experiments monitor.

One can rearrange and sort from the tui before using.

This also introduces a "modal" interface pattern, where we press a letter to enter a mode.

In this case it is the letter "q", then number of numeric columns to draw charts, then the number of columns to merge for the plot-label (useful when a e.g. a single optimizer has multiple modes, and the combined label is the true chart label).

## Usage Instructions

1. Sort 

In the run experiments monitor, first organize (h and l) and sort (press enter) on the columns to print.

Arrange these with numeric values on the left and labels to combine on the right, as below:

![image](https://github.com/user-attachments/assets/dcd73f17-9e58-4e59-b801-5c2926265ed6)

3. Enter hotkeys

For the above we want to print 3 numeric values and label by the subsequent two columns, so we press:
```
q 3 2
```
This will pop up a window in the browser:

4. View output

From the data above, we obtain the plot below;
![image](https://github.com/user-attachments/assets/b85a286b-1660-4f5e-8104-dab86a123304)

Keep in mind that the order in the tui is the order the charts will appear, and one could choose to sort the columns individually by pressing enter on each.