### PR TITLE
Add text wrap and rem plots folder

### DIFF
--- a/explorations/optimizers.yaml
+++ b/explorations/optimizers.yaml
@@ -46,6 +46,26 @@ optimizer:
 - sgdw
 - shampoo
 - swats
+- var_adaptive_lr
+- sophiag
+- soap
+- lookahead
+
+lookahead_inner_opt:
+  conditions:
+    - ["optimizer", "lookahead"]
+  options: ["adamw", "adamod", "diffgrad", "sophiag"]
+
+# conditional options
+lookahead_k:
+  conditions:
+    - ["optimizer", "lookahead"]
+  options: ["6", "8"]
+
+lookahead_alpha:
+  conditions:
+    - ["optimizer", "lookahead"]
+  options: ["0.3", "0.5"]
 
 # conditional options
 sgd_nesterov:

--- a/plot_view.py
+++ b/plot_view.py
@@ -44,8 +44,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Set, DefaultDict
 
 import itertools
+import os
 import matplotlib.pyplot as plt
 
+# ──────────────────────────── file-saving helper ───────────────────────────
+PLOT_DIR = "rem_plots" #  all plots will be saved here by default
+os.makedirs(PLOT_DIR, exist_ok=True)
+
+def _safe_path(title: str, ext: str = ".png") -> str:
+    """Sanitise *title* into a filename inside *PLOT_DIR*."""
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in title)
+    return os.path.join(PLOT_DIR, safe + ext)
 
 # ───────────────────────────── helpers ──────────────────────────────
 
@@ -155,10 +164,7 @@ def plot_rows(
     plt.legend(loc="best", fontsize=8)
     plt.tight_layout()
     plt.show()
-    safe_title = "".join(
-        ch if ch.isalnum() or ch in "-_." else "_" for ch in title
-    )
-    fig.savefig(f"{safe_title}.png", dpi=300)
+    fig.savefig(_safe_path(title), dpi=300)
     plt.show()
 
 
@@ -215,25 +221,23 @@ def plot_bars(
     )
     fig.update_traces(textposition="outside")
     fig.update_layout(
-    title=dict(
-        text=title_text,
-        x=0.5,             # halfway across the plot *area*
-        xref="container",  # ← key line: ignore the margins
-        xanchor="center",
-        yanchor="top",
-    ),
-        # merged column names become the Y-axis title
-    yaxis=dict(
-        title=" / ".join(label_cols),   # e.g. "optimizer / sgd_nesterov"
-        autorange="reversed",           # keep smallest bar on top
-    ),
-    xaxis=dict(title=y),
-    margin=dict(l=120, r=40, t=80, b=40),  # t a bit larger for the centred title
-)
+            title=dict(
+                text=title_text,
+                x=0.5,             # halfway across the plot *area*
+                xref="container",  # ← key line: ignore the margins
+                xanchor="center",
+                yanchor="top",
+                ),
+            # merged column names become the Y-axis title
+            yaxis=dict(
+                title=" / ".join(label_cols),   # e.g. "optimizer / sgd_nesterov"
+                autorange="reversed",           # keep smallest bar on top
+                ),
+            xaxis=dict(title=y),
+            margin=dict(l=120, r=40, t=80, b=40),  # t a bit larger for the centred title
+    )
 
-
-    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in title_text)
-    fig.write_image(f"{safe}.png", scale=2)  # requires kaleido
+    fig.write_image(_safe_path(title_text), scale=2)  # requires kaleido
     fig.show()
 
 # ───────────────────────────── plot multi bars ──────────────────────────────
@@ -318,8 +322,7 @@ def plot_multi_bars(
         legend_title_text="Metric",
     )
 
-    safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in fig.layout.title.text)
-    fig.write_image(f"{safe}.png", scale=2)  # kaleido needed
+    fig.write_image(_safe_path(fig.layout.title.text), scale=2)  # kaleido
     fig.show()
 
 # ───────────────────────────── CLI wrapper ──────────────────────────

--- a/plot_view.py
+++ b/plot_view.py
@@ -46,6 +46,7 @@ from typing import Any, Dict, List, Set, DefaultDict
 import itertools
 import os
 import matplotlib.pyplot as plt
+import textwrap
 
 # ──────────────────────────── file-saving helper ───────────────────────────
 PLOT_DIR = "rem_plots" #  all plots will be saved here by default
@@ -55,6 +56,16 @@ def _safe_path(title: str, ext: str = ".png") -> str:
     """Sanitise *title* into a filename inside *PLOT_DIR*."""
     safe = "".join(ch if ch.isalnum() or ch in "-_." else "_" for ch in title)
     return os.path.join(PLOT_DIR, safe + ext)
+
+# ───────────────────────────── title-wrap helper ───────────────────────────
+def _wrap_title(title: str, width: int = 60, *, html: bool = False) -> str:
+    """
+    Return *title* wrapped at *width* characters.
+
+    Matplotlib understands newlines, whereas Plotly needs <br>.
+    """
+    sep = "<br>" if html else "\n"
+    return sep.join(textwrap.wrap(title, width=width))
 
 # ───────────────────────────── helpers ──────────────────────────────
 
@@ -160,7 +171,7 @@ def plot_rows(
     if connect_by:
         disp = connect_label or connect_by   # NEW
         title += f"  (lines grouped by '{disp}')"
-    plt.title(title)
+    plt.title(_wrap_title(title))
     plt.legend(loc="best", fontsize=8)
     plt.tight_layout()
     plt.show()
@@ -222,7 +233,7 @@ def plot_bars(
     fig.update_traces(textposition="outside")
     fig.update_layout(
             title=dict(
-                text=title_text,
+                text=_wrap_title(title_text, html=True),
                 x=0.5,             # halfway across the plot *area*
                 xref="container",  # ← key line: ignore the margins
                 xanchor="center",
@@ -313,8 +324,11 @@ def plot_multi_bars(
     # ── common layout bits ────────────────────────────────────────────
     fig.update_layout(
         title=dict(
-            text=f"{' / '.join(map(pretty, y_cols))} by "
+            text=_wrap_title(
+                 f"{' / '.join(map(pretty, y_cols))} by "
                  f"{' / '.join(map(pretty, label_cols))}",
+                html=True,
+             ),
             x=0.5, xanchor="center", yanchor="top",
         ),
         bargap=0.15,

--- a/train_args.py
+++ b/train_args.py
@@ -148,6 +148,7 @@ def parse_args():
             "sophiag",
             "soap",
             "var_adaptive_lr",
+            "lookahead",
             ]
 
     training_group.add_argument("--optimizer", type=str, default="adamw",
@@ -230,6 +231,19 @@ def parse_args():
     training_group.add_argument("--apollo_update_proj_gap", type=int, default=200, help="# of optimisation steps between projector refresh.")
     training_group.add_argument("--apollo_proj_type", type=str, default="std", choices=["std", "gaussian", "rademacher"], help="Distribution for generating the projection matrix.")
     training_group.add_argument("--apollo_apply_to_all", action=argparse.BooleanOptionalAction, default=False, help="If set, apply low-rank Apollo updates to *all* " "parameters instead of only tensors tagged with " "`.lowrank = True`.")
+    training_group.add_argument("--lookahead_inner_opt",
+                                type=str,
+                                default="adamw",
+                                choices=optimizer_variations,
+                                help="Inner/fast optimiser that Lookahead will wrap.")
+    training_group.add_argument("--lookahead_k",
+                                type=int,
+                                default=6,
+                                help="Number of inner-optimiser steps before a slow weight sync.")
+    training_group.add_argument("--lookahead_alpha",
+                                type=float,
+                                default=0.5,
+                                help="Interpolation factor for the slow update (0 < α ≤ 1).")
 
 
     # from torch-optimizer (common)

--- a/train_args.py
+++ b/train_args.py
@@ -145,6 +145,8 @@ def parse_args():
             "sgdw",
             "shampoo",
             "swats",
+            "sophiag",
+            "soap",
             ]
 
     training_group.add_argument("--optimizer", type=str, default="adamw",
@@ -204,6 +206,13 @@ def parse_args():
     training_group.add_argument("--adafactor_scale_param", action=argparse.BooleanOptionalAction, default=True, help="Enable parameter-scale adaptive LR.")
     training_group.add_argument("--adafactor_relative_step", action=argparse.BooleanOptionalAction, default=True, help="Use relative-step schedule if learning rate is not supplied.")
     training_group.add_argument("--adafactor_warmup_init", action=argparse.BooleanOptionalAction, default=False, help="Use warm-up initialisation of learning rate.")
+    # Sophia-G
+    training_group.add_argument("--sophiag_beta1", type=float, default=0.96)
+    training_group.add_argument("--sophiag_beta2", type=float, default=0.99)
+    training_group.add_argument("--sophiag_rho",   type=float, default=0.04)
+    training_group.add_argument("--sophiag_update_freq", type=int, default=10)
+    # SOAP
+    training_group.add_argument("--soap_graft_lr", type=float, default=1.0)
 
     # AdaBelief -----------------------------------------------------------
     training_group.add_argument("--adabelief_eps", type=float, default=1e-16, help="AdaBelief epsilon.")

--- a/train_args.py
+++ b/train_args.py
@@ -147,6 +147,7 @@ def parse_args():
             "swats",
             "sophiag",
             "soap",
+            "var_adaptive_lr",
             ]
 
     training_group.add_argument("--optimizer", type=str, default="adamw",
@@ -213,6 +214,9 @@ def parse_args():
     training_group.add_argument("--sophiag_update_freq", type=int, default=10)
     # SOAP
     training_group.add_argument("--soap_graft_lr", type=float, default=1.0)
+    # Variance Adaptive Lr
+    training_group.add_argument("--varlr_beta", type=float, default=0.9, help="EMA smoothing for VarianceAdaptiveLR optimizer")
+
 
     # AdaBelief -----------------------------------------------------------
     training_group.add_argument("--adabelief_eps", type=float, default=1e-16, help="AdaBelief epsilon.")

--- a/train_variations/optimizer_variants.py
+++ b/train_variations/optimizer_variants.py
@@ -293,6 +293,239 @@ def _ademamix(param_groups, args):
         weight_decay=args.weight_decay,
     )
 
+################################################################################
+# Sophia-G  (Diagonal Hessian + clipped Newton step)
+# Paper: “Sophia: A Scalable Stochastic Second-order Optimizer for  
+#         Language Modeling”  – Ma et al., 2023-24 (v4)
+# URL :  https://arxiv.org/abs/2305.14342
+################################################################################
+
+class SophiaG(Optimizer):
+    r"""
+    **Sophia-G** keeps (1) a momentum buffer *m*  and (2) a *running diagonal
+    Hessian* estimate *h*.  Every `update_freq` steps it refreshes *h*
+    with the squared gradient; between refreshes it reuses the stale value,
+    making the extra cost negligible in wall-clock terms.
+
+       m_t   = β₁ m_{t-1} + (1-β₁) g_t
+       h_t   = β₂ h_{t-1} + (1-β₂) g_t²          (only on refresh steps)
+       Δ_t   = clip( m_t / (h_t + ε) ,  -ρ , ρ )
+       θ_{t+1} = θ_t − η Δ_t      (  AdamW-style decoupled weight-decay first )
+
+    Args
+    ----
+    params        : iterable of Tensors
+    lr            : learning rate          (η)
+    betas         : (β₁, β₂)               momentum & Hessian EMA factors
+    rho           : clipping threshold     (ρ in the paper, default 0.04)
+    update_freq   : refresh period for h_t (k  in the paper, default 10)
+    eps           : numerical epsilon
+    weight_decay  : decoupled weight decay
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-4,
+        betas: tuple[float, float] = (0.96, 0.99),
+        rho: float = 0.04,
+        update_freq: int = 10,
+        eps: float = 1e-8,
+        weight_decay: float = 0.0,
+    ):
+        if lr <= 0.0:
+            raise ValueError("Invalid learning rate")
+        if update_freq < 1:
+            raise ValueError("update_freq must be ≥ 1")
+        defaults = dict(
+            lr=lr,
+            betas=betas,
+            rho=rho,
+            update_freq=update_freq,
+            eps=eps,
+            weight_decay=weight_decay,
+        )
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None if closure is None else closure()
+        for group in self.param_groups:
+            lr, eps, wd = group["lr"], group["eps"], group["weight_decay"]
+            beta1, beta2 = group["betas"]
+            rho, k = group["rho"], group["update_freq"]
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                g = p.grad.detach()
+                state = self.state[p]
+
+                # ── state init ────────────────────────────────────────────
+                if len(state) == 0:
+                    state["step"] = 0
+                    state["m"] = torch.zeros_like(p, dtype=torch.float32)
+                    state["h"] = torch.zeros_like(p, dtype=torch.float32)
+
+                m, h = state["m"], state["h"]
+                state["step"] += 1
+                t = state["step"]
+
+                # ── momentum ──────────────────────────────────────────────
+                m.mul_(beta1).add_(g, alpha=1 - beta1)
+
+                # ── Hessian diag update every k steps ────────────────────
+                if t % k == 0:
+                    h.mul_(beta2).addcmul_(g, g, value=1 - beta2)
+
+                # ── decoupled weight-decay (AdamW style) ─────────────────
+                if wd != 0.0:
+                    p.data.mul_(1 - lr * wd)
+
+                # ── pre-conditioned & clipped update ─────────────────────
+                denom = h.add(eps)            # element-wise
+                update = m / denom
+                update.clamp_(min=-rho, max=rho)
+                p.data.add_(update, alpha=-lr)
+        return loss
+
+
+################################################################################
+# SOAP  –  “Shampoo plus Adam in the Eigen-basis”  (Mohan et al., 2024-25)
+# Very memory-heavy but ~-40 % tokens-to-target on GPT-J / OPT-1.3 B.
+#
+# Implementation note
+# -------------------
+# •  We reuse torch-optimizer’s Kronecker-factored **Shampoo** to get the
+#    pre-conditioned gradient `g̃`.  Inside SOAP we *also* keep an Adam-style
+#    first-moment buffer on that pre-conditioned gradient – exactly as in the
+#    paper (“momentum in the eigen-basis”).
+# •  If `torch_optimizer.Shampoo` is unavailable we raise an ImportError with
+#    a helpful hint (keeps repo importable even on minimal installs).
+################################################################################
+
+try:
+    from torch_optimizer import Shampoo as _ToptShampoo
+except (ModuleNotFoundError, ImportError):
+    _ToptShampoo = None
+
+
+class SOAP(Optimizer):
+    r"""
+    SOAP = **S**hampoo-**O**rthogonal **A**dam-grafted **P**rojection
+
+    Stats per parameter
+    -------------------
+    •  _ToptShampoo keeps the Kronecker factors and their running inverses;
+    •  we keep *one* extra momentum buffer **m** in the *Shampoo basis*.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-4,
+        betas: tuple[float, float] = (0.9, 0.999),   # (β₁  for m,  β₂ for Shampoo)
+        eps: float = 1e-12,
+        weight_decay: float = 0.0,
+        momentum: float = 0.9,        # reused for Shampoo
+        update_freq: int = 1,         # Shampoo pre-condition freq
+        graft_lr: float = 1.0,        # LR multiplier after grafting
+    ):
+        if _ToptShampoo is None:
+            raise ImportError(
+                "`torch-optimizer` not found.  Install with:\n"
+                "    pip install torch-optimizer[shampoo]\n"
+                "or choose a different optimiser."
+            )
+
+        defaults = dict(
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            momentum=momentum,
+            update_freq=update_freq,
+            graft_lr=graft_lr,
+        )
+        super().__init__(params, defaults)
+
+        # A *real* Shampoo instance to handle Kronecker math & inverse roots
+        self._shampoo = _ToptShampoo(
+            params,
+            lr=1.0,                       # handled by SOAP itself
+            momentum=momentum,
+            epsilon=eps,
+            weight_decay=0.0,             # decay handled in outer loop
+            update_freq=update_freq,
+        )
+
+        # we must NOT let torch-optimizer step the params – override later
+        self._shampoo.step = lambda *a, **kw: None
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None if closure is None else closure()
+
+        # 1) Let Shampoo compute **pre-conditioned grads** (stored on .grad)
+        self._shampoo.precondition_grads()   # no param update here
+
+        # 2) Adam-style first-moment + weight decay + param update
+        for group in self.param_groups:
+            lr, eps = group["lr"], group["eps"]
+            beta1, _ = group["betas"]
+            wd, η = group["weight_decay"], group["graft_lr"]
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+
+                state = self.state[p]
+                if len(state) == 0:
+                    state["m"] = torch.zeros_like(p.grad, dtype=torch.float32)
+                m = state["m"]
+
+                # Shampoo has already given us *g̃*  (pre-conditioned grad)
+                g_tilde = p.grad
+
+                # Momentum in the Shampoo eigen-basis
+                m.mul_(beta1).add_(g_tilde, alpha=1 - beta1)
+
+                # Decoupled weight decay
+                if wd != 0.0:
+                    p.data.mul_(1 - lr * wd)
+
+                # Final update  (optionally graft lr)
+                p.data.add_(m, alpha=-lr * η)
+
+        return loss
+
+# ──────────────────────────────────────────────────────────────────────────────
+#  Factory helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _sophiag(param_groups, args):
+    return SophiaG(
+        param_groups,
+        lr=args.learning_rate,
+        betas=(args.sophiag_beta1, args.sophiag_beta2),
+        rho=args.sophiag_rho,
+        update_freq=args.sophiag_update_freq,
+        eps=args.opt_eps,
+        weight_decay=args.opt_weight_decay,
+    )
+
+
+def _soap(param_groups, args):
+    return SOAP(
+        param_groups,
+        lr=args.learning_rate,
+        betas=(args.beta1, args.beta2),
+        eps=args.opt_eps,
+        weight_decay=args.opt_weight_decay,
+        momentum=args.shampoo_momentum,
+        update_freq=args.shampoo_update_freq,
+        graft_lr=args.soap_graft_lr,
+    )
 
 ###############################################################################
 # AdamS (Momentum-as-Normalizer) – Huishuai Zhang et al. 2024
@@ -1166,4 +1399,6 @@ optimizer_dictionary: dict[str, callable] = {
     "swats": _swats,
     "qhadam": _qhadam,
     "yogi": _yogi,
+    "sophiag": _sophiag,
+    "soap": _soap,
 }


### PR DESCRIPTION
# Change Summary

1. Plots from run_exploration_monitor.py now save into rem_plots instead of root repo folder.
2. Text now wraps for autosaved plot images:
![Best_Val_Loss___Iter_Latency_Avg___Peak_Gpu_Mb_by_Lookahead_br_Inner_Opt___Lookahead_K___Lookahead_Alpha](https://github.com/user-attachments/assets/bd6bd0e0-9153-4848-b5a4-2cb9e85c2343)
