### PR TITLE
Add layer sequence layerlist support

### DIFF
--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -150,9 +150,11 @@ class GPTConfig:
     # MLP
     shared_mlp_size: int = 1
     shared_mlp_sym: bool = False
+    shared_mlp_seq: int = 1
     # ATTN
     shared_attn_size: int = 1
     shared_attn_sym: bool = False
+    shared_attn_seq: int = 1
 
     # Softmax Alternatives and Options
     softmax_variant_attn: str = "softmax" # Choices: "softmax" "softermax" "sigsoftmax" "polymax" "strongermax" "consmax"

--- a/optimization_and_search/run_experiments.py
+++ b/optimization_and_search/run_experiments.py
@@ -38,7 +38,7 @@ def parse_args() -> argparse.Namespace:
         help="Path to the configuration file."
     )
     parser.add_argument(
-        '--config_format', choices=['json', 'yaml'], default='json',
+        '--config_format', choices=['json', 'yaml'], default='yaml',
         help="Configuration file format (json or yaml)."
     )
     parser.add_argument(

--- a/train_args.py
+++ b/train_args.py
@@ -387,8 +387,10 @@ def parse_args():
     # Shared Parameter Settings
     model_group.add_argument('--shared_mlp_size', default=1, type=int, help="every 'k' contiguous blocks of mlp are shared")
     model_group.add_argument('--shared_mlp_sym', default=False, action=argparse.BooleanOptionalAction)
+    model_group.add_argument('--shared_mlp_seq', default=1, type=int)
     model_group.add_argument('--shared_attn_size', default=1, type=int, help="every 'k' contiguous blocks of attn are shared")
     model_group.add_argument('--shared_attn_sym', default=False, action=argparse.BooleanOptionalAction, help="symmetrical attention sharing")
+    model_group.add_argument('--shared_attn_seq', default=1, type=int)
 
     # NORM VARIATIONS
     norm_variations = [

--- a/train_args.py
+++ b/train_args.py
@@ -387,10 +387,10 @@ def parse_args():
     # Shared Parameter Settings
     model_group.add_argument('--shared_mlp_size', default=1, type=int, help="every 'k' contiguous blocks of mlp are shared")
     model_group.add_argument('--shared_mlp_sym', default=False, action=argparse.BooleanOptionalAction)
-    model_group.add_argument('--shared_mlp_seq', default=1, type=int)
+    model_group.add_argument('--shared_mlp_seq', default=1, type=int, help="Sequence length for cyclic sharing of MLP layers")
     model_group.add_argument('--shared_attn_size', default=1, type=int, help="every 'k' contiguous blocks of attn are shared")
     model_group.add_argument('--shared_attn_sym', default=False, action=argparse.BooleanOptionalAction, help="symmetrical attention sharing")
-    model_group.add_argument('--shared_attn_seq', default=1, type=int)
+    model_group.add_argument('--shared_attn_seq', default=1, type=int, help="Sequence length for cyclic sharing of attention layers")
 
     # NORM VARIATIONS
     norm_variations = [


### PR DESCRIPTION
This pull request introduces enhancements to the shared parameter configuration and management in the codebase, along with a minor default configuration change. The most notable updates include the addition of sequence-based sharing for MLP and attention layers, improved configurability, and a debug printing feature for shared parameter groups.

### Enhancements to shared parameter configuration:
* Added new configuration options `shared_mlp_seq` and `shared_attn_seq` for sequence-based sharing of MLP and attention layers in `gpt_conf.py` and `train_args.py`. These parameters allow cyclic sharing of blocks across a defined sequence length. (`[[1]](diffhunk://#diff-114e7747956438292f72cb8316c075c30638fe5c68dab6a7ac466f33639df288R153-R157)`, `[[2]](diffhunk://#diff-57e38b30e53f063cb302643ce9937858a55f279e201aad1b1f6425a4332b86d9R390-R393)`)
* Updated the `create_shared_param_group` method in `shared_param_utils.py` to support sequence-based sharing. Introduced logic for cyclic sequence sharing, symmetry mirroring, and a helper function `_build_block` to streamline block creation. (`[[1]](diffhunk://#diff-93e625420ca72df92e2bc76c52130e7ab916678023e65b9d235237e77a88dec7R68-R73)`, `[[2]](diffhunk://#diff-93e625420ca72df92e2bc76c52130e7ab916678023e65b9d235237e77a88dec7L74-R116)`, `[[3]](diffhunk://#diff-93e625420ca72df92e2bc76c52130e7ab916678023e65b9d235237e77a88dec7L145-R267)`)

### Debugging and visualization improvements:
* Added a debug printing feature to visualize shared parameter groups using `rich` tables. This includes a mapping of layers to sequence letters (e.g., A, B, C) and additional details like MLP sizes. (`[shared_param_utils.pyL145-R267](diffhunk://#diff-93e625420ca72df92e2bc76c52130e7ab916678023e65b9d235237e77a88dec7L145-R267)`)

### Minor changes:
* Changed the default configuration format from `json` to `yaml` in `run_experiments.py`. (`[optimization_and_search/run_experiments.pyL41-R41](diffhunk://#diff-0a54d7401d1b0b1ceef5356bde8f00cd5e2bf0cfd514f0bc7434b2d28fdef869L41-R41)`)
* Added imports for `rich.console`, `rich.table`, and `rich.text` in `shared_param_utils.py` to support the new debug printing feature. (`[shared_param_utils.pyR10-R15](diffhunk://#diff-93e625420ca72df92e2bc76c52130e7ab916678023e65b9d235237e77a88dec7R10-R15)`)

![image](https://github.com/user-attachments/assets/a86203b9-b21f-4495-943c-070f7360ea8e)
