### PR TITLE
feat: Add DualPathMLP and parameter-matched experiments

### DIFF
--- a/explorations/dual_path_sweep.yaml
+++ b/explorations/dual_path_sweep.yaml
@@ -18,4 +18,4 @@ eval_interval: [10000]
 eta_variant: ["iteration"]
 
 # compilation
-compile: [true] 
+compile: [true]

--- a/explorations/dual_path_sweep.yaml
+++ b/explorations/dual_path_sweep.yaml
@@ -12,9 +12,12 @@ parameter_groups:
 activation_variant: ["relu", "gelu", "softplus"]
 
 # training configuration
-batch_size: [64]
-gradient_accumulation_steps: [1]
-eval_interval: [10000]
+dataset: "minipile"
+max_iters: 10000
+lr_decay_iters: 10000
+warmup_iters: 1000
+decay_lr: [true]
+eval_interval: 10000
 eta_variant: ["iteration"]
 
 # compilation

--- a/explorations/mlp_bias_comparison.yaml
+++ b/explorations/mlp_bias_comparison.yaml
@@ -27,9 +27,14 @@ n_head: [12]
 n_embd: [768]
 bias: [false]
 
-# device and compilation
-device: ["cuda"]
-compile: [true]
+# training configuration
+dataset: "minipile"
+max_iters: 10000
+lr_decay_iters: 10000
+warmup_iters: 1000
+decay_lr: [true]
+eval_interval: 10000
+eta_variant: ["iteration"]
 
-# dataset configuration
-dataset: ["minipile"]
+# compilation
+compile: [true]

--- a/explorations/mlp_bias_comparison.yaml
+++ b/explorations/mlp_bias_comparison.yaml
@@ -32,4 +32,4 @@ device: ["cuda"]
 compile: [true]
 
 # dataset configuration
-dataset: ["minipile"] 
+dataset: ["minipile"]

--- a/explorations/mlp_variation_comparison.yaml
+++ b/explorations/mlp_variation_comparison.yaml
@@ -14,27 +14,15 @@ parameter_groups:
   - mlp_variant: ["dual_path"]
     mlp_size: [512, 683, 1024]
 
-# base hyperparameters
-block_size: [256]
-n_layer: [6]
-n_head: [6]
-n_embd: [384]
-
-# training configuration
-batch_size: [64]
-gradient_accumulation_steps: [1]
-eval_interval: [10000]
-eta_variant: ["iteration"]
-
 # compilation
 compile: [true]
 
 # training configuration
-learning_rate: [6e-4]
-min_lr: [6e-5]
 max_iters: [10000]
 lr_decay_iters: [10000]
-warmup_iters: [100]
+eval_interval: [10000]
+eta_variant: ["iteration"]
+warmup_iters: [1000]
 decay_lr: [true]
 
 # dataset configuration

--- a/train_args.py
+++ b/train_args.py
@@ -17,8 +17,8 @@ def parse_args():
     logging_group = parser.add_argument_group('logging_group')
 
     # MLP Bias Configuration
-    model_group.add_argument('--mlp_up_bias', type=bool, default=None, help='Whether to use bias in MLP up projections. If None, uses global bias setting.')
-    model_group.add_argument('--mlp_down_bias', type=bool, default=None, help='Whether to use bias in MLP down projections. If None, uses global bias setting.')
+    model_group.add_argument('--mlp_up_bias', type=bool, default=None, action=argparse.BooleanOptionalAction, help='Whether to use bias in MLP up projections. If None, uses global bias setting.')
+    model_group.add_argument('--mlp_down_bias', type=bool, default=None, action=argparse.BooleanOptionalAction, help='Whether to use bias in MLP down projections. If None, uses global bias setting.')
 
     # DualPath MLP Configuration
     model_group.add_argument('--dual_path_x_offset', type=float, default=0.01, help='X-axis offset for DualPath activation functions')

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -125,9 +125,15 @@ class DualPathMLP(nn.Module):
         self.activation_variant = activation_dictionary[config.activation_variant](config=config)
         
         # Dual path specific parameters
-        self.activation_x_offset = nn.Parameter(torch.tensor(config.dual_path_x_offset)) if config.learn_dual_path_x_offset else torch.tensor(config.dual_path_x_offset)
-        self.activation_y_offset = nn.Parameter(torch.tensor(config.dual_path_y_offset)) if config.learn_dual_path_y_offset else torch.tensor(config.dual_path_y_offset)
+        if config.learn_dual_path_x_offset:
+            self.activation_x_offset = nn.Parameter(torch.tensor(config.dual_path_x_offset))
+        else:
+            self.register_buffer("activation_x_offset", torch.tensor(config.dual_path_x_offset))
 
+        if config.learn_dual_path_y_offset:
+            self.activation_y_offset = nn.Parameter(torch.tensor(config.dual_path_y_offset))
+        else:
+            self.register_buffer("activation_y_offset", torch.tensor(config.dual_path_y_offset))
         # Sets the class of linear for MLP
         self.linear_variant_mlp_up = linear_dictionary[set_variant(config.linear_variant_mlp_up, config.linear_variant_mlp)]
         self.linear_variant_mlp_down = linear_dictionary[set_variant(config.linear_variant_mlp_down, config.linear_variant_mlp)]


### PR DESCRIPTION
# MLP Variations and Parameter-Matched Experiments

This PR introduces new MLP variations and experiment configurations for comparing different MLP architectures with matched parameter counts.

## Changes

1. Added new DualPathMLP variation:
   - Single upscale projection followed by two activation paths
   - Configurable x and y offsets with optional learning
   - Separate bias configurations for up/down projections

2. Updated GPTConfig:
   - Added DualPath specific parameters
   - Added separate mlp_up_bias and mlp_down_bias configurations

3. Added three new experiment configurations:
   - `dual_path_sweep.yaml`: Explores DualPath specific parameters
   - `mlp_variation_comparison.yaml`: Compares MLP variants with matched parameter counts
   - `mlp_bias_comparison.yaml`: Studies bias effects with matched parameter counts

## Parameter Count Matching

For fair comparison, MLP sizes are adjusted to match parameter counts:
- MLP: Uses larger sizes (e.g., 768)
- Swiglu/DualPath: Uses ~2/3 of MLP sizes (e.g., 512) due to having 3 projections vs 2

## Testing

The experiment configurations are set up to:
1. Compare perplexity across architectures with equal parameter counts
2. Study the impact of bias configurations
3. Explore DualPath's unique parameters

## Next Steps

1. Run the experiments
2. Analyze results focusing on:
   - Perplexity vs parameter count efficiency
   - Impact of bias configurations
   - Optimal DualPath parameter settings 