### PR TITLE
Modify explorations for dual path and mlp

### DIFF
--- a/explorations/dual_path_sweep.yaml
+++ b/explorations/dual_path_sweep.yaml
@@ -2,14 +2,21 @@
 ---
 # parameter_groups: define sets of overrides to apply on top of base params
 parameter_groups:
+  - mlp_variant: ["mlp"]
+    mlp_size: ["2304"]
+  - mlp_variant: ["swiglu"]
   - mlp_variant: ["dual_path"]
-    dual_path_x_offset: [0.01, 0.1, 1.0]
-    dual_path_y_offset: [-0.1, 0.0, 0.1]
+    dual_path_x_offset: [0.01, 0.05, 0.1, 1.0]
+    dual_path_y_offset: [-0.01, 0.0, 0.01]
     learn_dual_path_x_offset: [true, false]
     learn_dual_path_y_offset: [true, false]
 
 # MLP specific parameters
-activation_variant: ["relu", "gelu", "softplus"]
+activation_variant: ["relu", "gelu", "softplus", "identity"]
+
+# Position embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
 
 # training configuration
 dataset: "minipile"

--- a/explorations/mlp_bias_comparison.yaml
+++ b/explorations/mlp_bias_comparison.yaml
@@ -20,12 +20,9 @@ parameter_groups:
     mlp_up_bias: [true, false]
     mlp_down_bias: [true, false]
 
-# base hyperparameters (defaults)
-block_size: [512]
-n_layer: [12]
-n_head: [12]
-n_embd: [768]
-bias: [false]
+# Position embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
 
 # training configuration
 dataset: "minipile"

--- a/explorations/mlp_variation_comparison.yaml
+++ b/explorations/mlp_variation_comparison.yaml
@@ -13,9 +13,20 @@ parameter_groups:
   # DualPath - ~2/3 of MLP sizes for same param count
   - mlp_variant: ["dual_path"]
     mlp_size: [512, 683, 1024]
+    learn_dual_path_x_offset: [true]
+    learn_dual_path_y_offset: [true]
+    dual_path_x_offset: [0.1]
+    dual_path_y_offset: [0.0]
+
+# activation type
+activation_variant: ["relu"]
 
 # compilation
 compile: [true]
+
+# Position embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [false]
 
 # training configuration
 max_iters: [10000]
@@ -27,6 +38,7 @@ decay_lr: [true]
 
 # dataset configuration
 dataset: ["minipile"]
+
 
 # dtype
 dtype: ["float16", "bfloat16"]


### PR DESCRIPTION
Adds positional embeddings, and keeps everything to same base parameters for layer counts and heads.