### PR TITLE
feat: Add multiple down projections to MLP/SwiGLU

### DIFF
--- a/explorations/multi_proj_mlp.yaml
+++ b/explorations/multi_proj_mlp.yaml
@@ -1,14 +1,8 @@
 # multi_proj_mlp.yaml
 ---
 # Base hyperparameters
-max_iters: [3500]
-n_layer: [6]
-n_head: [6]
-n_embd: [384]
-block_size: [256]
-device: ["cuda"]
-dtype: ["bfloat16"]
-dataset: ["shakespeare_char"]
+dtype: ["float16", "bfloat16"]
+dataset: ["minipile"]
 
 # MLP variations to test
 mlp_variant:
@@ -22,37 +16,16 @@ n_down_projs:
     end: 4
     step: 1
 
-# Learning rate variations
-learning_rate: [1e-3, 3e-3]
-min_lr: [1e-4]
-
-# Optimizer settings
-optimizer: ["adamw"]
-weight_decay: [0.1]
-grad_clip: [1.0]
-
-# Training settings
-batch_size: [64]
-dropout: [0.0, 0.1]
-
 # Compile and device settings
 compile: [true]
-use_gradient_checkpointing: [false]
 
 # Logging settings
-eval_interval: [250]
-log_interval: [10]
-tensorboard_log: [true]
-tensorboard_run_name: ["multi_proj_mlp_study"]
+eval_interval: [10000]
+max_iters: [10000]
 
 # Positional embeddings
 use_rotary_embeddings: [true]
-use_abs_pos_embeddings: [true]
-
-# Activation and normalization
-activation_variant: ["gelu"]
-norm_variant_attn: ["rmsnorm"]
-norm_variant_output: ["rmsnorm"]
+use_abs_pos_embeddings: [false]
 
 # Random seeds for reproducibility
 seed:

--- a/explorations/multi_proj_mlp.yaml
+++ b/explorations/multi_proj_mlp.yaml
@@ -1,0 +1,62 @@
+# multi_proj_mlp.yaml
+---
+# Base hyperparameters
+max_iters: [3500]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+block_size: [256]
+device: ["cuda"]
+dtype: ["bfloat16"]
+dataset: ["shakespeare_char"]
+
+# MLP variations to test
+mlp_variant:
+  - mlp
+  - swiglu
+
+# Number of down projections to test
+n_down_projs:
+  range:
+    start: 1
+    end: 4
+    step: 1
+
+# Learning rate variations
+learning_rate: [1e-3, 3e-3]
+min_lr: [1e-4]
+
+# Optimizer settings
+optimizer: ["adamw"]
+weight_decay: [0.1]
+grad_clip: [1.0]
+
+# Training settings
+batch_size: [64]
+dropout: [0.0, 0.1]
+
+# Compile and device settings
+compile: [true]
+use_gradient_checkpointing: [false]
+
+# Logging settings
+eval_interval: [250]
+log_interval: [10]
+tensorboard_log: [true]
+tensorboard_run_name: ["multi_proj_mlp_study"]
+
+# Positional embeddings
+use_rotary_embeddings: [true]
+use_abs_pos_embeddings: [true]
+
+# Activation and normalization
+activation_variant: ["gelu"]
+norm_variant_attn: ["rmsnorm"]
+norm_variant_output: ["rmsnorm"]
+
+# Random seeds for reproducibility
+seed:
+  range:
+    start: 1337
+    end: 1339
+    step: 1 

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -13,6 +13,7 @@ class GPTConfig:
     n_head: int = 12
     n_kv_group: int = 12
     n_embd: int = 768
+    n_down_projs: int = 1  # Number of down projections in MLP/SwiGLU
 
     # For multicontext training
     multicontext: bool = False

--- a/train_args.py
+++ b/train_args.py
@@ -325,6 +325,7 @@ def parse_args():
     model_group.add_argument('--n_head', default=6, type=int)
     model_group.add_argument('--n_kv_group', default=None, type=int)
     model_group.add_argument('--n_embd', default=384, type=int, help="Size of embeddings in decoder layer and wte unless n_embd_wte is set." )
+    model_group.add_argument('--n_down_projs', default=1, type=int, help="Number of down projections in MLP/SwiGLU")
     model_group.add_argument('--n_embd_wte', default=None, type=int, help="If different from n_embd, an adapter table will be automatically created")
     model_group.add_argument('--n_embd_wte_scale_tying', default=True, action=argparse.BooleanOptionalAction, help="Enable weight tying for scale up and scale down matrices, only has effects if n_embd_wte is not 'None'.")
     model_group.add_argument('--wte_weight_tying', default=True, action=argparse.BooleanOptionalAction, help="Enable weight tying for non-factorized wte")

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -109,7 +109,7 @@ class OriginalMLP(nn.Module):
             x = mlp_res
 
         # Apply multiple down projections and sum their outputs
-        x_out = torch.zeros_like(x)
+        x_out = 0
         for c_proj in self.c_projs:
             x_out += c_proj(x)
         x = x_out / self.n_down_projs  # Average the outputs

--- a/variations/mlp_variations.py
+++ b/variations/mlp_variations.py
@@ -109,7 +109,7 @@ class OriginalMLP(nn.Module):
             x = mlp_res
 
         # Apply multiple down projections and sum their outputs
-        x_out = 0
+        x_out = torch.zeros_like(x)
         for c_proj in self.c_projs:
             x_out += c_proj(x)
         x = x_out / self.n_down_projs  # Average the outputs


### PR DESCRIPTION
Add support for multiple parallel down projections in MLP/SwiGLU architectures. Adds n_down_projs parameter and configuration for systematic exploration of the feature's impact.