### PR TITLE
Improve formatting for compute model stats table

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,6 @@ to add new features and explorations.
 - NanoGPT Discord Channel [![](https://dcbadge.vercel.app/api/server/3zy8kqD9Cp?compact=true&style=flat)](https://discord.gg/3zy8kqD9Cp)
 - [Zero To Hero series](https://karpathy.ai/zero-to-hero.html)
 - [GPT video](https://www.youtube.com/watch?v=kCc8FmEb1nY)
+
+![Alt](https://repobeats.axiom.co/api/embed/c372c58e1f19f91b5e4223627f2bd9c8a702d390.svg "Repobeats analytics image")
+

--- a/README.md
+++ b/README.md
@@ -223,6 +223,3 @@ to add new features and explorations.
 - NanoGPT Discord Channel [![](https://dcbadge.vercel.app/api/server/3zy8kqD9Cp?compact=true&style=flat)](https://discord.gg/3zy8kqD9Cp)
 - [Zero To Hero series](https://karpathy.ai/zero-to-hero.html)
 - [GPT video](https://www.youtube.com/watch?v=kCc8FmEb1nY)
-
-![Alt](https://repobeats.axiom.co/api/embed/c372c58e1f19f91b5e4223627f2bd9c8a702d390.svg "Repobeats analytics image")
-

--- a/train.py
+++ b/train.py
@@ -38,7 +38,11 @@ from utils.statistic_plots import (
     create_statistics,
 )
 
-from utils.model_stats import compute_weight_stats, compute_activation_stats
+from utils.model_stats import (
+    compute_weight_stats,
+    compute_activation_stats,
+    print_model_stats_table,
+)
 
 from sample import (
     sample_with_existing_model,
@@ -902,18 +906,7 @@ class Trainer:
             self.latest_overall_weight_stats     = overall_wt
             self.latest_overall_activation_stats = overall_act
 
-            print("Weight Statistics per tensor:")
-            for name, s in weight_stats.items():
-                print(
-                    f"{name}: stdev {s['stdev']:.6f}, kurtosis {s['kurtosis']:.6f}, "
-                    f"max {s['max']:.6f}, min {s['min']:.6f}, abs_max {s['abs_max']:.6f}"
-                )
-            print("Activation Statistics per tensor:")
-            for name, s in act_stats.items():
-                print(
-                    f"{name}: stdev {s['stdev']:.6f}, kurtosis {s['kurtosis']:.6f}, "
-                    f"max {s['max']:.6f}, min {s['min']:.6f}, abs_max {s['abs_max']:.6f}"
-                )
+            print_model_stats_table(weight_stats, act_stats)
         else:
             act_stats  = {}   # keep API intact
             weight_stats = {}

--- a/utils/model_stats.py
+++ b/utils/model_stats.py
@@ -164,8 +164,17 @@ def print_model_stats_table(weight_stats: Dict[str, Dict], act_stats: Dict[str, 
                 # largest value should be green, smallest most red
                 t = (hi - val) / (hi - lo)
             elif key == "kurtosis":
-                # negative -> green, positive -> red
-                t = (val - lo) / (hi - lo)
+                # negative -> green, positive -> red. Use log scaling for
+                # smoother gradation over wide ranges.
+                abs_max = max(abs(lo), abs(hi))
+                if abs_max == 0:
+                    t = 0.5
+                else:
+                    norm = math.log(1 + abs(val)) / math.log(1 + abs_max)
+                    if val >= 0:
+                        t = 0.5 + 0.5 * norm
+                    else:
+                        t = 0.5 - 0.5 * norm
             else:
                 base = abs(val)
                 t = (base - lo) / (hi - lo)


### PR DESCRIPTION
# Improved formatting for compute model stats table

This change adds per column gradient highlighting to quickly see the patterns:

<img width="1116" height="1239" alt="image" src="https://github.com/user-attachments/assets/a9a01cf5-ac4d-404f-bc8b-ee9eb92b52e2" />

The kurtosis and abs_max are in an (augmented) log scale, to still see patterns despite outliers in particular from the mlp activations.

## Usage

For lower number of layers (e.g. 6 as per default):

```bash
python3 train.py --compute_model_stats
```
Or if running more layers one may need to prevent tensorboard from becoming overloaded:
```bash
python3 train.py --compute_model_stats --no-tensorboard_log
```