### PR TITLE
Refactor pre peri post and block variations

### DIFF
--- a/data/template/tokenizers.py
+++ b/data/template/tokenizers.py
@@ -135,7 +135,9 @@ class TiktokenTokenizer(Tokenizer):
                 name=f"{self.tiktoken_encoding}_custom",
                 pat_str=base_enc._pat_str,
                 mergeable_ranks=base_enc._mergeable_ranks,
-                special_tokens={**base_enc._special_tokens, **self.additional_tokens}
+                special_tokens={**base_enc._special_tokens,
+                                **self.additional_tokens},
+                disallowed_special=(),
             )
             self.special_tokens = self.additional_tokens
         else:
@@ -171,7 +173,11 @@ class TiktokenTokenizer(Tokenizer):
                 chunk = data[current_pos:next_special]
                 if chunk:
                     # Use encode() for proper subword tokenization
-                    chunk_ids = self.enc.encode(chunk, allowed_special=set())
+                    chunk_ids = self.enc.encode(
+                            chunk,
+                            allowed_special=set(),
+                            disallowed_special=(),
+                            )
                     token_ids.extend(chunk_ids)
                     for token_id in chunk_ids:
                         self.record_token(token_id)

--- a/explorations/block_settings_sweep.yaml
+++ b/explorations/block_settings_sweep.yaml
@@ -2,10 +2,11 @@
 ---
 
 # base hyperparameters
-max_iters: [10000]
-n_layer: [5]
-n_head: [5]
-n_embd: [320]
+max_iters: [20000]
+n_layer: [6]
+n_head: [6]
+n_embd: [384]
+eval_interval: [500]
 block_size: [256]
 device: ["cuda"]
 dataset: ["minipile"]
@@ -24,15 +25,16 @@ compute_model_stats: [true]
 # VARIATIONS
 
 # floating point
-dtype: ["bfloat16", "float16"]
+dtype: ["float16"]
 
 # compilation tests
-compile: [true, false]
+compile: [true]
 
 # variation tests
 use_parallel_mlp: [true, false]
+use_pre_ln:  [true, false]
 use_peri_ln: [true, false]
 use_post_ln: [true, false]
 
 # checkpointing tests
-use_gradient_checkpointing: [true, false]
+# use_gradient_checkpointing: [true, false]

--- a/gpt_conf.py
+++ b/gpt_conf.py
@@ -308,6 +308,7 @@ class GPTConfig:
 
     # Structuring Options, remember to compile the model
     use_post_ln: bool = False
+    use_pre_ln: bool = True
     use_peri_ln: bool = False
 
     # Layernorm Alternatives and Options

--- a/train_args.py
+++ b/train_args.py
@@ -358,9 +358,9 @@ def parse_args():
     model_group.add_argument('--n_embd_wte_scale_tying', default=True, action=argparse.BooleanOptionalAction, help="Enable weight tying for scale up and scale down matrices, only has effects if n_embd_wte is not 'None'.")
     model_group.add_argument('--wte_weight_tying', default=True, action=argparse.BooleanOptionalAction, help="Enable weight tying for non-factorized wte")
     model_group.add_argument('--dropout', default=0.0, type=float)
-    model_group.add_argument('--use_post_ln', default=False, action=argparse.BooleanOptionalAction)
-    model_group.add_argument('--use_peri_ln', default=False, action=argparse.BooleanOptionalAction,
-                             help="apply layer norm before and after sublayers")
+    model_group.add_argument('--use_pre_ln', default=True,   action=argparse.BooleanOptionalAction, help="apply before any attn or mlp")
+    model_group.add_argument('--use_peri_ln', default=False, action=argparse.BooleanOptionalAction, help="apply directly after each attn and mlp")
+    model_group.add_argument('--use_post_ln', default=False, action=argparse.BooleanOptionalAction, help="apply after recombining the residual")
     model_group.add_argument('--window_size', default=None, type=int, help="Sliding window size, note this cannot be greater than block size")
     model_group.add_argument('--gate', default=False, action=argparse.BooleanOptionalAction, help="option for gated attention see https://arxiv.org/abs/2306.12929")
     model_group.add_argument('--use_moe', default=False,  action=argparse.BooleanOptionalAction, help="option for Mixture of Experts (MoE) architecture")

--- a/variations/block_variations.py
+++ b/variations/block_variations.py
@@ -15,32 +15,61 @@ BlockForward = Callable[['Block', torch.Tensor, int], torch.Tensor]
 
 def parallel_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     """Forward pass where attention and MLP run in parallel."""
-    if block.use_peri_ln:
-        ln_1 = block.ln_1(x)
-        attn_out = block.out_ln_attn(block.attn(ln_1, iter_num))
-        mlp_out = block.out_ln_mlp(block.mlp(ln_1, iter_num))
-        x = x + attn_out + mlp_out
-    elif block.use_post_ln:
-        x = block.ln_1(x + block.attn(x, iter_num) + block.mlp(x, iter_num))
-    else:  # pre-LN
-        ln_1 = block.ln_1(x)
-        x = x + block.attn(ln_1, iter_num) + block.mlp(ln_1, iter_num)
+    if block.use_pre_ln: # pre-LN
+        x_1 = block.pre_ln(x)
+    else:
+        x_1 = x
+
+    if block.use_peri_ln: # peri-LN
+        attn_out = block.out_ln_attn(block.attn(x_1, iter_num))
+        mlp_out = block.out_ln_mlp(block.mlp(x_1, iter_num))
+    else:
+        attn_out = block.attn(x_1, iter_num)
+        mlp_out = block.mlp(x_1, iter_num)
+
+    x = x + attn_out + mlp_out
+
+    if block.use_post_ln: # post-LN
+        x = block.post_ln(x)
+
     return x
 
 
 def attn_then_mlp_forward(block, x: torch.Tensor, iter_num: int) -> torch.Tensor:
     """Attention followed by MLP."""
-    if block.use_peri_ln:
-        attn_out = block.out_ln_attn(block.attn(block.ln_1(x), iter_num))
-        x = x + attn_out
-        mlp_out = block.out_ln_mlp(block.mlp(block.ln_2(x), iter_num))
-        x = x + mlp_out
-    elif block.use_post_ln:
-        x = block.ln_1(x + block.attn(x, iter_num))
-        x = block.ln_2(x + block.mlp(x, iter_num))
-    else:  # pre-LN
-        x = x + block.attn(block.ln_1(x), iter_num)
-        x = x + block.mlp(block.ln_2(x), iter_num)
+
+    # Attn
+    if block.use_pre_ln: # pre-LN Attn
+        x_1 = block.pre_ln_attn(x)
+    else:
+        x_1 = x
+
+    if block.use_peri_ln: # peri-LN Attn
+        attn_out = block.out_ln_attn(block.attn(x_1, iter_num))
+    else:
+        attn_out = block.attn(x_1, iter_num)
+
+    x = attn_out + x
+
+    if block.use_post_ln: # post-LN Attn
+        x = block.post_ln_attn(x)
+
+    # MLP
+    if block.use_pre_ln: # pre-LN MLP
+        x_2 = block.pre_ln_mlp(x)
+    else:
+        x_2 = x
+
+    if block.use_peri_ln: # peri-LN MLP
+        mlp_out = block.out_ln_mlp(block.mlp(x_2, iter_num))
+    else:
+        mlp_out = block.mlp(x_2, iter_num)
+
+    x = mlp_out + x
+
+    if block.use_post_ln: # post-LN MLP
+        x = block.post_ln_mlp(x)
+
     return x
 
 
@@ -57,17 +86,37 @@ class Block(nn.Module):
         super().__init__()
 
         norm_cls = norm_dictionary[config.norm_variant_attn]
-        self.ln_1 = norm_cls(config)
-        if not config.use_parallel_mlp:
-            self.ln_2 = norm_cls(config)
 
+        # Pre-Norm
+        if config.use_pre_ln:
+            if config.use_parallel_mlp:
+                # parallel uses 1 less pre ln
+                self.pre_ln = norm_cls(config)
+            else:
+                self.pre_ln_attn = norm_cls(config)
+                self.pre_ln_mlp = norm_cls(config)
+
+        # Post-Norm
+        if config.use_post_ln:
+            if config.use_parallel_mlp:
+                # parallel uses 1 less post ln
+                self.post_ln = norm_cls(config)
+            else:
+                self.post_ln_attn = norm_cls(config)
+                self.post_ln_mlp = norm_cls(config)
+
+        # Pero-LN
         if config.use_peri_ln:
             self.out_ln_attn = norm_cls(config)
             self.out_ln_mlp = norm_cls(config)
 
+
+        self.use_pre_ln  = config.use_pre_ln
         self.use_post_ln = config.use_post_ln
         self.use_peri_ln = config.use_peri_ln
+
         self.use_parallel_mlp = config.use_parallel_mlp
+
         self.use_gradient_checkpointing = config.use_gradient_checkpointing
 
         variant = "parallel_mlp" if self.use_parallel_mlp else "attn_then_mlp"


### PR DESCRIPTION
# Individual and Modular Settings for Pre Peri and Post LN 

This refactors a recent merge, to allow for testing normalization at each of the stages between the attn and mlp.

Each of these is now supported in both parallel_mlp and sequential (attn then mlp) block variations.

## Changes

1. pre-ln is now default true and controls the before attn and mlp normalization
2. peri-ln is default false, and controls whether output of attn and mlp is directly normalized
3. post-is is (still) default false, and controls whether the post-res-add vector is normalized before sending to the next layer.